### PR TITLE
fix: prevent phi node addIncoming from always throwing

### DIFF
--- a/src/IR/PHINode.cpp
+++ b/src/IR/PHINode.cpp
@@ -45,6 +45,7 @@ void PHINode::addIncoming(const Napi::CallbackInfo &info) {
         llvm::Value *value = Value::Extract(info[0]);
         llvm::BasicBlock *basicBlock = BasicBlock::Extract(info[1]);
         phiNode->addIncoming(value, basicBlock);
+    } else {
+        throw Napi::TypeError::New(info.Env(), ErrMsg::Class::PHINode::addIncoming);
     }
-    throw Napi::TypeError::New(info.Env(), ErrMsg::Class::PHINode::addIncoming);
 }


### PR DESCRIPTION
The `addIncoming` function on phi nodes always throws, looks like a missing else