### PR TITLE
Fixed type definition of [Type].isIntegerTy(width)

### DIFF
--- a/llvm-bindings.d.ts
+++ b/llvm-bindings.d.ts
@@ -261,7 +261,7 @@ declare namespace llvm {
 
         public isTokenTy(): boolean;
 
-        public isIntegerTy(bitWidth?: number): boolean;
+        public isIntegerTy(bitWidth: number): boolean;
 
         public isFunctionTy(): boolean;
 


### PR DESCRIPTION
The isIntegerTy is defined to optionally take a number, 
even though at runtime, it throws an error; asking for a value to be passed