### PR TITLE
LLVM 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test/temp/
 
 /**/**/.DS_Store
 cmake_install.cmake
+llvm-bindings.d.ts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,14 @@ string(REGEX REPLACE "[\r\n\"]" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
 # Add a library to generate the TypeScript declarations
 add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/llvm-bindings.d.ts.cpp
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/llvm-bindings.in.d.ts ${CMAKE_CURRENT_BINARY_DIR}/llvm-bindings.d.ts.cpp
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_CURRENT_SOURCE_DIR}/llvm-bindings.in.d.ts
+            ${CMAKE_CURRENT_BINARY_DIR}/llvm-bindings.d.ts.cpp
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/llvm-bindings.in.d.ts
 )
 add_library(ts_decl_lib OBJECT ${CMAKE_CURRENT_BINARY_DIR}/llvm-bindings.d.ts.cpp)
 target_link_libraries(ts_decl_lib ${LLVM_LIBS})
-target_compile_options(ts_decl_lib PRIVATE -E -P)
+target_compile_options(ts_decl_lib PRIVATE -E -P --traditional-cpp)
 target_include_directories(ts_decl_lib PRIVATE ${LLVM_INCLUDE_DIRS})
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC} ${NODE_ADDON_API_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,12 @@ execute_process(
 string(REGEX REPLACE "[\r\n\"]" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
 
 # Add a library to generate the TypeScript declarations
-add_library(ts_decl_lib OBJECT llvm-bindings.d.ts.cpp)
+add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/llvm-bindings.d.ts.cpp
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/llvm-bindings.in.d.ts ${CMAKE_CURRENT_BINARY_DIR}/llvm-bindings.d.ts.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/llvm-bindings.in.d.ts
+)
+add_library(ts_decl_lib OBJECT ${CMAKE_CURRENT_BINARY_DIR}/llvm-bindings.d.ts.cpp)
 target_link_libraries(ts_decl_lib ${LLVM_LIBS})
 target_compile_options(ts_decl_lib PRIVATE -E -P)
 target_include_directories(ts_decl_lib PRIVATE ${LLVM_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.17)
 
 project(llvm-bindings)
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -26,8 +27,22 @@ execute_process(
 
 string(REGEX REPLACE "[\r\n\"]" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
 
+# Add a library to generate the TypeScript declarations
+add_library(ts_decl_lib OBJECT llvm-bindings.d.ts.cpp)
+target_link_libraries(ts_decl_lib ${LLVM_LIBS})
+target_compile_options(ts_decl_lib PRIVATE -E -P)
+target_include_directories(ts_decl_lib PRIVATE ${LLVM_INCLUDE_DIRS})
+
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC} ${NODE_ADDON_API_DIR})
 
 target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} ${LLVM_LIBS})
 
 add_definitions(-DNAPI_VERSION=8)
+
+add_custom_target(
+        ts_declarations
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_OBJECTS:ts_decl_lib>" ${CMAKE_CURRENT_SOURCE_DIR}/llvm-bindings.d.ts
+        DEPENDS ts_decl_lib
+)
+
+add_dependencies(${PROJECT_NAME} ts_declarations)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Due to the limitation of `node-addon-api`, this project has not implemented inhe
 | 0.2.x                  | 12.0.x                   |
 | 0.3.x                  | 13.0.x                   |
 | 0.4.x                  | 14.0.x                   |
+| 0.5.x                  | 16.0.x                   |
 
 ## Acknowledgments
 - [MichaReiser](https://github.com/MichaReiser): the creator of [llvm-node](https://github.com/MichaReiser/llvm-node)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npm install llvm-bindings
 ## Usage
 
 ```javascript
-import llvm from 'llvm-bindings.d.ts.cpp';
+import llvm from 'llvm-bindings';
 
 function main(): void {
     const context = new llvm.LLVMContext();

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npm install llvm-bindings
 ## Usage
 
 ```javascript
-import llvm from 'llvm-bindings';
+import llvm from 'llvm-bindings.d.ts.cpp';
 
 function main(): void {
     const context = new llvm.LLVMContext();

--- a/cmake/CMakeJS.cmake
+++ b/cmake/CMakeJS.cmake
@@ -37,17 +37,15 @@ endfunction(GET_VARIABLE)
 string(TOLOWER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_LOWER)
 
 if (CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
-    exec_program(
-            ${CMakeJS}
-            ${CMAKE_CURRENT_SOURCE_DIR}
-            ARGS print-configure --debug
+    execute_process(
+            COMMAND ${CMakeJS} print-configure --debug
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             OUTPUT_VARIABLE CMAKE_JS_OUTPUT
     )
 else ()
-    exec_program(
-            ${CMakeJS}
-            ${CMAKE_CURRENT_SOURCE_DIR}
-            ARGS print-configure
+    execute_process(
+            COMMAND ${CMakeJS} print-configure
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             OUTPUT_VARIABLE CMAKE_JS_OUTPUT
     )
 endif ()

--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -5,7 +5,7 @@ if (CMAKE_HOST_APPLE)
     endforeach ()
 endif ()
 
-find_package(LLVM 14 REQUIRED CONFIG)
+find_package(LLVM 16 REQUIRED CONFIG)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 

--- a/include/IR/DerivedTypes.h
+++ b/include/IR/DerivedTypes.h
@@ -228,5 +228,5 @@ private:
 
     Napi::Value getTypeID(const Napi::CallbackInfo &info);
 
-    Napi::Value getPointerElementType(const Napi::CallbackInfo &info);
+    Napi::Value getNonOpaquePointerElementType(const Napi::CallbackInfo &info);
 };

--- a/include/IR/Type.h
+++ b/include/IR/Type.h
@@ -39,7 +39,7 @@ private:
         return Napi::Boolean::New(info.Env(), (type->*method)());
     }
 
-    Napi::Value getPointerElementType(const Napi::CallbackInfo &info);
+    Napi::Value getNonOpaquePointerElementType(const Napi::CallbackInfo &info);
 
     static Napi::Value isSameType(const Napi::CallbackInfo &info);
 };

--- a/include/assert.h
+++ b/include/assert.h
@@ -1,0 +1,13 @@
+#ifndef __LLVM_BINDINGS_NODEJS_ASSERT__
+#define __LLVM_BINDINGS_NODEJS_ASSERT__
+
+#ifdef __cplusplus
+void llvm_bindings_assert(const char* expr, const char* file, int line);
+
+#define __assert(e, file, line) ((void)llvm_bindings_assert ((e), (file), (line)))
+
+#define assert(e) ((void) ((e) ? ((void)0) : __assert (#e, __FILE__, __LINE__)))
+
+#endif
+
+#endif

--- a/llvm-bindings.d.ts.cpp
+++ b/llvm-bindings.d.ts.cpp
@@ -98,84 +98,12 @@ declare namespace llvm {
 
     class Attribute {
         public static readonly AttrKind: {
-            AlwaysInline: number;
-            ArgMemOnly: number;
-            Builtin: number;
-            Cold: number;
-            Convergent: number;
-            DisableSanitizerInstrumentation: number;
-            Hot: number;
-            ImmArg: number;
-            InReg: number;
-            InaccessibleMemOnly: number;
-            InaccessibleMemOrArgMemOnly: number;
-            InlineHint: number;
-            JumpTable: number;
-            MinSize: number;
-            MustProgress: number;
-            Naked: number;
-            Nest: number;
-            NoAlias: number;
-            NoBuiltin: number;
-            NoCallback: number;
-            NoCapture: number;
-            NoCfCheck: number;
-            NoDuplicate: number;
-            NoFree: number;
-            NoImplicitFloat: number;
-            NoInline: number;
-            NoMerge: number;
-            NoProfile: number;
-            NoRecurse: number;
-            NoRedZone: number;
-            NoReturn: number;
-            NoSanitizeCoverage: number;
-            NoSync: number;
-            NoUndef: number;
-            NoUnwind: number;
-            NonLazyBind: number;
-            NonNull: number;
-            NullPointerIsValid: number;
-            OptForFuzzing: number;
-            OptimizeForSize: number;
-            OptimizeNone: number;
-            ReadNone: number;
-            ReadOnly: number;
-            Returned: number;
-            ReturnsTwice: number;
-            SExt: number;
-            SafeStack: number;
-            SanitizeAddress: number;
-            SanitizeHWAddress: number;
-            SanitizeMemTag: number;
-            SanitizeMemory: number;
-            SanitizeThread: number;
-            ShadowCallStack: number;
-            Speculatable: number;
-            SpeculativeLoadHardening: number;
-            StackProtect: number;
-            StackProtectReq: number;
-            StackProtectStrong: number;
-            StrictFP: number;
-            SwiftAsync: number;
-            SwiftError: number;
-            SwiftSelf: number;
-            UWTable: number;
-            WillReturn: number;
-            WriteOnly: number;
-            LastEnumAttr: number;
-            ByRef: number;
-            ByVal: number;
-            ElementType: number;
-            InAlloca: number;
-            Preallocated: number;
-            LastTypeAttr: number;
-            Alignment: number;
-            AllocSize: number;
-            Dereferenceable: number;
-            DereferenceableOrNull: number;
-            StackAlignment: number;
-            VScaleRange: number;
+
+#define GET_ATTR_NAMES
+#define ATTRIBUTE_ENUM(EnumName, lower) \
+            EnumName: number;
+#include "llvm/IR/Attributes.inc"
+
         };
 
         public static get(context: LLVMContext, kind: number, value?: number): Attribute;
@@ -1942,7 +1870,6 @@ declare namespace llvm {
         const expect_with_probability: number;
         const fabs: number;
         const floor: number;
-        const flt_rounds: number;
         const fma: number;
         const fmuladd: number;
         const fptosi_sat: number;

--- a/llvm-bindings.in.d.ts
+++ b/llvm-bindings.in.d.ts
@@ -2,12 +2,15 @@ declare namespace llvm {
     class APInt {
         public constructor(numBits: number, value: number, isSigned?: boolean);
     }
+
     class APFloat {
         public constructor(value: number);
     }
+
     namespace LLVMConstants {
         const DEBUG_METADATA_VERSION: number;
     }
+
     namespace dwarf {
         namespace LLVMConstants {
             const DWARF_VERSION: number;
@@ -76,7 +79,9 @@ declare namespace llvm {
             const DW_LANG_hi_user: number;
         }
     }
+
     function WriteBitcodeToFile(module: Module, filename: string): void;
+
     namespace config {
         const LLVM_DEFAULT_TARGET_TRIPLE: string;
         const LLVM_HOST_TRIPLE: string;
@@ -86,9 +91,11 @@ declare namespace llvm {
         const LLVM_VERSION_PATCH: number;
         const LLVM_VERSION_STRING: string;
     }
+
     class LLVMContext {
         public constructor();
     }
+
     class Attribute {
         public static readonly AttrKind: {
 
@@ -101,8 +108,10 @@ declare namespace llvm {
         public static get(context: LLVMContext, kind: number, value?: number): Attribute;
         public static get(context: LLVMContext, kind: string, value?: string): Attribute;
         public static get(context: LLVMContext, kind: number, type: Type): Attribute;
+
         protected constructor();
     }
+
     class Module {
         public static readonly ModFlagBehavior: {
             Error: number;
@@ -115,25 +124,44 @@ declare namespace llvm {
             ModFlagBehaviorFirstVal: number;
             ModFlagBehaviorLastVal: number;
         }
+
         public constructor(moduleID: string, context: LLVMContext);
+
         public getModuleIdentifier(): string;
+
         public getSourceFileName(): string;
+
         public getName(): string;
+
         public getDataLayoutStr(): string;
+
         public getDataLayout(): DataLayout;
+
         public getTargetTriple(): string;
+
         public setModuleIdentifier(moduleID: string): void;
+
         public setSourceFileName(sourceFileName: string): void;
+
         public setDataLayout(desc: string): void;
         public setDataLayout(dataLayout: DataLayout): void;
+
         public setTargetTriple(triple: string): void;
+
         public getFunction(name: string): Function | null;
+
         public getOrInsertFunction(name: string, funcType: FunctionType): FunctionCallee;
+
         public getGlobalVariable(name: string, allowInternal?: boolean): GlobalVariable | null;
+
         public addModuleFlag(behavior: number, key: string, value: number): void;
+
         public empty(): boolean;
+
+        // customized
         public print(): string;
     }
+
     class Type {
         public static readonly TypeID: {
             HalfTyID: number;
@@ -156,155 +184,308 @@ declare namespace llvm {
             FixedVectorTyID: number;
             ScalableVectorTyID: number;
         };
+
         public static getVoidTy(context: LLVMContext): Type;
+
         public static getLabelTy(context: LLVMContext): Type;
+
         public static getHalfTy(context: LLVMContext): Type;
+
         public static getBFloatTy(context: LLVMContext): Type;
+
         public static getFloatTy(context: LLVMContext): Type;
+
         public static getDoubleTy(context: LLVMContext): Type;
+
         public static getMetadataTy(context: LLVMContext): Type;
+
         public static getX86_FP80Ty(context: LLVMContext): Type;
+
         public static getFP128Ty(context: LLVMContext): Type;
+
         public static getPPC_FP128Ty(context: LLVMContext): Type;
+
         public static getX86_MMXTy(context: LLVMContext): Type;
+
         public static getTokenTy(context: LLVMContext): Type;
+
         public static getIntNTy(context: LLVMContext, numBits: number): IntegerType;
+
         public static getInt1Ty(context: LLVMContext): IntegerType;
+
         public static getInt8Ty(context: LLVMContext): IntegerType;
+
         public static getInt16Ty(context: LLVMContext): IntegerType;
+
         public static getInt32Ty(context: LLVMContext): IntegerType;
+
         public static getInt64Ty(context: LLVMContext): IntegerType;
+
         public static getInt128Ty(context: LLVMContext): IntegerType;
+
         public static getHalfPtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getBFloatPtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getFloatPtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getDoublePtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getX86_FP80PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getFP128PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getPPC_FP128PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getX86_MMXPtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getInt1PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getInt8PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getInt16PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getInt32PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public static getInt64PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
+
         public getTypeID(): number;
+
         public isVoidTy(): boolean;
+
         public isHalfTy(): boolean;
+
         public isBFloatTy(): boolean;
+
         public isFloatTy(): boolean;
+
         public isDoubleTy(): boolean;
+
         public isX86_FP80Ty(): boolean;
+
         public isFP128Ty(): boolean;
+
         public isPPC_FP128Ty(): boolean;
+
         public isFloatingPointTy(): boolean;
+
         public isX86_MMXTy(): boolean;
+
         public isLabelTy(): boolean;
+
         public isMetadataTy(): boolean;
+
         public isTokenTy(): boolean;
+
         public isIntegerTy(bitWidth?: number): boolean;
+
         public isFunctionTy(): boolean;
+
         public isStructTy(): boolean;
+
         public isArrayTy(): boolean;
+
         public isPointerTy(): boolean;
+
         public isVectorTy(): boolean;
+
         public isEmptyTy(): boolean;
+
         public isFirstClassType(): boolean;
+
         public isSingleValueType(): boolean;
+
         public isAggregateType(): boolean;
+
         public getPointerTo(addrSpace?: number): PointerType;
+
         public getPrimitiveSizeInBits(): number;
+
         public getPointerElementType(): Type;
+
+        // extra
         public static isSameType(type1: Type, type2: Type): boolean;
+
         protected constructor();
     }
+
     class IntegerType extends Type {
         public static get(context: LLVMContext, numBits: number): IntegerType;
+
+        // duplicated
         public isStructTy(): boolean;
+
+        // duplicated
         public isIntegerTy(bitWidth?: number): boolean;
+
+        // duplicated
         public isVoidTy(): boolean;
+
+        // duplicated
         public getTypeID(): number;
+
         protected constructor();
     }
+
     class FunctionType extends Type {
         public static get(returnType: Type, isVarArg: boolean): FunctionType;
         public static get(returnType: Type, paramTypes: Type[], isVarArg: boolean): FunctionType;
+
+        // duplicated
         public isVoidTy(): boolean;
+
+        // duplicated
         public getTypeID(): number;
+
         protected constructor();
     }
+
     class FunctionCallee {
         public getFunctionType(): FunctionType;
+
         public getCallee(): Value;
+
         protected constructor();
     }
+
     class StructType extends Type {
         public static create(context: LLVMContext, name: string): StructType;
         public static create(context: LLVMContext, elementTypes: Type[], name: string): StructType;
+
         public static get(context: LLVMContext): StructType;
         public static get(context: LLVMContext, elementTypes: Type[]): StructType;
+
         public getTypeByName(name: string): StructType | null;
+
         public setBody(elementTypes: Type[]): void;
+
         public setName(name: string): void;
+
         public hasName(): boolean;
+
         public getName(): string;
+
         public isOpaque(): boolean;
+
         public isPacked(): boolean;
+
         public isLiteral(): boolean;
+
+        // duplicated
         public getPointerTo(addrSpace?: number): PointerType;
+
+        // duplicated
         public isStructTy(): boolean;
+
+        // duplicated
         public isIntegerTy(bitWidth?: number): boolean;
+
+        // duplicated
         public isVoidTy(): boolean;
+
+        // duplicated
         public getTypeID(): number;
+
         protected constructor();
     }
+
     class ArrayType extends Type {
         public static get(elemType: Type, numElements: number): ArrayType;
+
         public static isValidElementType(elemType: Type): boolean;
+
         public getNumElements(): number;
+
         public getElementType(): Type;
+
+        // duplicated
         public isStructTy(): boolean;
+
+        // duplicated
         public isVoidTy(): boolean;
+
+        // duplicated
         public getTypeID(): number;
+
         protected constructor();
     }
+
     class VectorType extends Type {
+        // duplicated
         public isStructTy(): boolean;
+
+        // duplicated
         public isVoidTy(): boolean;
+
+        // duplicated
         public getTypeID(): number;
+
         protected constructor();
     }
+
     class PointerType extends Type {
         public static get(elementType: Type, addrSpace: number): PointerType;
+
         public static getUnqual(elementType: Type): PointerType;
+
+        // duplicated
         public isPointerTy(): boolean;
+
+        // duplicated
         public isStructTy(): boolean;
+
+        // duplicated
         public isIntegerTy(bitWidth?: number): boolean;
+
+        // duplicated
         public isVoidTy(): boolean;
+
+        // duplicated
         public getTypeID(): number;
+
+        // duplicated
         public getPointerElementType(): Type;
+
         protected constructor();
     }
+
     class Value {
         public static MaxAlignmentExponent: number;
         public static MaximumAlignment: number;
+
         public getType(): Type;
+
         public hasName(): boolean;
+
         public getName(): string;
+
         public setName(name: string): void;
+
         public deleteValue(): void;
+
         public replaceAllUsesWith(newValue: Value): void;
+
         public use_empty(): boolean;
+
         public user_empty(): boolean;
+
         protected constructor();
     }
+
     class Argument extends Value {
         public constructor(type: Type, name?: string, func?: Function, argNo?: number);
+
         public getParent(): Function;
+
         public getArgNo(): number;
+
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setName(name: string): void;
     }
+
     class BasicBlock extends Value {
         public static Create(
             context: LLVMContext,
@@ -312,84 +493,145 @@ declare namespace llvm {
             parent?: Function,
             insertBefore?: BasicBlock
         ): BasicBlock;
+
         public getParent(): Function | null;
+
         public getModule(): Module | null;
+
         public getTerminator(): Instruction | null;
+
         public getFirstNonPHI(): Instruction | null;
+
         public insertInto(parent: Function, insertBefore?: BasicBlock): void;
+
         public removeFromParent(): void;
+
+        // customized
         public eraseFromParent(): void;
+
+        // duplicated
         public use_empty(): boolean;
+
+        // duplicated
         public getType(): Type;
+
+        // extra
         public deleteSelf(): void;
+
         protected constructor();
     }
+
     class User extends Value {
         public getOperand(i: number): Value;
+
         public setOperand(i: number, value: Value): void;
+
         public getNumOperands(): number;
+
+        // duplicated
         public getType(): Type;
+
         protected constructor();
     }
+
     class Constant extends User {
         public static getNullValue(type: Type): Constant;
+
         public static getAllOnesValue(type: Type): Constant;
+
         public isNullValue(): boolean;
+
         public isOneValue(): boolean;
+
         public isAllOnesValue(): boolean;
+
+        // duplicated
         public getType(): Type;
+
         protected constructor();
     }
+
     class ConstantInt extends Constant {
         public static get(context: LLVMContext, value: APInt): ConstantInt;
         public static get(type: IntegerType, value: number, isSigned?: boolean): ConstantInt;
         public static get(type: Type, value: APInt): Constant;
         public static get(type: Type, value: number, isSigned?: boolean): Constant;
+
         public static getTrue(context: LLVMContext): ConstantInt;
+
         public static getFalse(context: LLVMContext): ConstantInt;
+
         public getType(): IntegerType;
+
         protected constructor();
     }
+
     class ConstantFP extends Constant {
         public static get(type: Type, value: number): Constant;
         public static get(type: Type, value: APFloat): Constant;
         public static get(type: Type, value: string): Constant;
         public static get(context: LLVMContext, value: APFloat): ConstantFP;
+
         public static getNaN(type: Type): Constant
+
+        // duplicated
         public getType(): Type;
+
         protected constructor();
     }
+
     class ConstantArray extends Constant {
         public static get(type: ArrayType, values: Constant[]): Constant;
+
         public getType(): ArrayType;
+
         protected constructor();
     }
+
     class ConstantStruct extends Constant {
         public static get(type: StructType, values: Constant[]): Constant;
+
         public getType(): StructType;
+
         protected constructor();
     }
+
     class ConstantPointerNull extends Constant {
         public static get(type: PointerType): ConstantPointerNull;
+
         public getType(): PointerType;
+
         protected constructor();
     }
+
     class ConstantDataArray extends Constant {
         public static get(context: LLVMContext, elements: number[]): Constant;
+
         public static getString(context: LLVMContext, initializer: string, addNull?: boolean): Constant;
+
         public getType(): ArrayType;
+
         protected constructor();
     }
+
     class ConstantExpr extends Constant {
         public static getBitCast(constant: Constant, type: Type): Constant;
+
+        // duplicated
         public getType(): Type;
+
         protected constructor();
     }
+
     class UndefValue extends Constant {
         public static get(type: Type): UndefValue;
+
+        // duplicated
         public getType(): Type;
+
         protected constructor();
     }
+
     class GlobalValue extends Constant {
         public static readonly LinkageTypes: {
             ExternalLinkage: number;
@@ -409,472 +651,959 @@ declare namespace llvm {
             HiddenVisibility: number;
             ProtectedVisibility: number;
         }
+
+        // duplicated
         public getType(): PointerType;
+
         public getValueType(): Type;
+
         protected constructor();
     }
+
     class GlobalObject extends GlobalValue {
+        // duplicated
         public getType(): PointerType;
+
+        // duplicated
         public getValueType(): Type;
+
         protected constructor();
     }
+
     class GlobalVariable extends GlobalObject {
+        // customized
         public constructor(type: Type, isConstant: boolean, linkage: number, initializer?: Constant | null, name?: string);
+        // customized
         public constructor(module: Module, type: Type, isConstant: boolean, linkage: number, initializer: Constant | null, name?: string);
+
+        // duplicated
         public getType(): PointerType;
+
+        // duplicated
         public getValueType(): Type;
+
         public setInitializer(initVal: Constant | null): void;
+
         public removeFromParent(): void;
+
         public eraseFromParent(): void;
+
         public addDebugInfo(gv: DIGlobalVariableExpression): void;
     }
+
     class Function extends GlobalObject {
         public static Create(funcType: FunctionType, linkage: number, name?: string, module?: Module): Function;
+
         public arg_size(): number;
+
         public getArg(i: number): Argument;
+
         public getReturnType(): Type;
+
+        // customized
         public addBasicBlock(basicBlock: BasicBlock): void;
+
         public getEntryBlock(): BasicBlock;
+
+        // extra
         public getExitBlock(): BasicBlock;
+
+        // customized
         public insertAfter(where: BasicBlock, basicBlock: BasicBlock): void;
+
         public deleteBody(): void;
+
         public removeFromParent(): void;
+
         public eraseFromParent(): void;
+
+        // duplicated
         public use_empty(): boolean;
+
+        // duplicated
         public user_empty(): boolean;
+
+        // duplicated
         public getNumUses(): number;
+
+        // duplicated
         public removeDeadConstantUsers(): void;
+
         public hasPersonalityFn(): boolean;
+
         public setPersonalityFn(fn: Constant): void;
+
         public setDoesNotThrow(): void;
+
         public setSubprogram(subprogram: DISubprogram): void;
+
         public getSubprogram(): DISubprogram;
+
+        // duplicated
         public getType(): PointerType;
+
         public addFnAttr(kind: number): void;
         public addFnAttr(attr: Attribute): void;
+
         public addParamAttr(argNo: number, kind: number): void;
         public addParamAttr(argNo: number, attr: Attribute): void;
+
         public addRetAttr(kind: number): void;
         public addRetAttr(attr: Attribute): void;
+
         protected constructor();
     }
+
     class Instruction extends User {
         public user_back(): Instruction | null;
+
         public getParent(): BasicBlock | null;
+
         public getModule(): Module | null;
+
         public getFunction(): Function | null;
+
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class AllocaInst extends Instruction {
         public getAllocatedType(): Type;
+
         public getArraySize(): Value;
+
+        // duplicated
         public getType(): PointerType;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class LoadInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class StoreInst extends Instruction {
         public getValueOperand(): Value;
+
         public getPointerOperand(): Value;
+
         public getPointerOperandType(): Type;
+
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class FenceInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class AtomicCmpXchgInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class AtomicRMWInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class GetElementPtrInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class ICmpInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class FCmpInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class CallInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class SelectInst extends Instruction {
         public getCondition(): Value;
+
         public getTrueValue(): Value;
+
         public getFalseValue(): Value;
+
         public setCondition(value: Value): void;
+
         public setTrueValue(value: Value): void;
+
         public setFalseValue(value: Value): void;
+
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class VAArgInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class ExtractElementInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class InsertElementInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class ShuffleVectorInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class ExtractValueInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class InsertValueInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class PHINode extends Instruction {
         public addIncoming(value: Value, basicBlock: BasicBlock): void;
+
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class LandingPadInst extends Instruction {
         public setCleanup(value: boolean): void;
+
         public addClause(clauseVal: Constant): void;
+
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class ReturnInst extends Instruction {
         public getReturnValue(): Value;
+
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class BranchInst extends Instruction {
         public isUnconditional(): boolean;
+
         public isConditional(): boolean;
+
         public getCondition(): Value;
+
         public getNumSuccessors(): number;
+
         public getSuccessor(i: number): BasicBlock;
+
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class SwitchInst extends Instruction {
         public addCase(onVal: ConstantInt, dest: BasicBlock): void;
+
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class IndirectBrInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class InvokeInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class CallBrInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class ResumeInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class CatchSwitchInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class CleanupPadInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class CatchPadInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class CatchReturnInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class CleanupReturnInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class UnreachableInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class TruncInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class ZExtInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class SExtInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class FPTruncInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class FPExtInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class UIToFPInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class SIToFPInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class FPToUIInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class FPToSIInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class IntToPtrInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class PtrToIntInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class BitCastInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class AddrSpaceCastInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class FreezeInst extends Instruction {
+        // duplicated
         public getType(): Type;
+
+        // duplicated
         public setDebugLoc(location: DebugLoc): void;
+
         protected constructor();
     }
+
     class IRBuilder {
         public constructor(context: LLVMContext);
         public constructor(theBB: BasicBlock);
         public constructor(ip: Instruction);
+
+        //===--------------------------------------------------------------------===//
+        // Builder configuration methods
+        //===--------------------------------------------------------------------===//
+
         public ClearInsertionPoint(): void;
+
         public GetInsertBlock(): BasicBlock | null;
+
         public SetInsertPoint(basicBlock: BasicBlock): void;
         public SetInsertPoint(inst: Instruction): void;
+
         public saveIP(): IRBuilder.InsertPoint;
+
         public saveAndClearIP(): IRBuilder.InsertPoint;
+
         public restoreIP(ip: IRBuilder.InsertPoint): void;
+
         public SetCurrentDebugLocation(location: DebugLoc): void;
+        // extra
         public SetCurrentDebugLocation(location: DILocation): void;
+
+        //===--------------------------------------------------------------------===//
+        // Miscellaneous creation methods.
+        //===--------------------------------------------------------------------===//
+
         public CreateGlobalString(str: string, name?: string, addrSpace?: number, module?: Module): GlobalVariable;
+
         public getInt1(value: boolean): ConstantInt;
+
         public getTrue(): ConstantInt;
+
         public getFalse(): ConstantInt;
+
         public getInt8(value: number): ConstantInt;
+
         public getInt16(value: number): ConstantInt;
+
         public getInt32(value: number): ConstantInt;
+
         public getInt64(value: number): ConstantInt;
+
         public getIntN(numBits: number, value: number): ConstantInt;
+
         public getInt(value: APInt): ConstantInt;
+
+        //===--------------------------------------------------------------------===//
+        // Type creation methods
+        //===--------------------------------------------------------------------===//
+
         public getInt1Ty(): IntegerType;
+
         public getInt8Ty(): IntegerType;
+
         public getInt16Ty(): IntegerType;
+
         public getInt32Ty(): IntegerType;
+
         public getInt64Ty(): IntegerType;
+
         public getInt128Ty(): IntegerType;
+
         public getIntNTy(numBits: number): IntegerType;
+
         public getHalfTy(): Type;
+
         public getBFloatTy(): Type;
+
         public getFloatTy(): Type;
+
         public getDoubleTy(): Type;
+
         public getVoidTy(): Type;
+
         public getInt8PtrTy(addrSpace?: number): PointerType;
+
         public getIntPtrTy(dataLayout: DataLayout, addrSpace?: number): IntegerType;
+
+        //===--------------------------------------------------------------------===//
+        // Instruction creation methods: Terminators
+        //===--------------------------------------------------------------------===//
+
         public CreateRetVoid(): ReturnInst;
+
         public CreateRet(value: Value): ReturnInst;
+
         public CreateBr(destBB: BasicBlock): BranchInst;
+
         public CreateCondBr(cond: Value, thenBB: BasicBlock, elseBB: BasicBlock): BranchInst;
+
         public CreateSwitch(value: Value, dest: BasicBlock, numCases?: number): SwitchInst;
+
         public CreateIndirectBr(addr: Value, numDests?: number): IndirectBrInst;
+
+        // customized
         public CreateInvoke(callee: Function, normalDest: BasicBlock, unwindDest: BasicBlock, name?: string): InvokeInst;
         public CreateInvoke(callee: Function, normalDest: BasicBlock, unwindDest: BasicBlock, args: Value[], name?: string): InvokeInst;
         public CreateInvoke(callee: FunctionCallee, normalDest: BasicBlock, unwindDest: BasicBlock, name?: string): InvokeInst;
         public CreateInvoke(callee: FunctionCallee, normalDest: BasicBlock, unwindDest: BasicBlock, args: Value[], name?: string): InvokeInst;
         public CreateInvoke(funcType: FunctionType, callee: Function, normalDest: BasicBlock, unwindDest: BasicBlock, name?: string): InvokeInst;
         public CreateInvoke(funcType: FunctionType, callee: Function, normalDest: BasicBlock, unwindDest: BasicBlock, args: Value[], name?: string): InvokeInst;
+
         public CreateResume(exn: Value): ResumeInst;
+
         public CreateUnreachable(): UnreachableInst;
+
+        //===--------------------------------------------------------------------===//
+        // Instruction creation methods: Binary Operators
+        //===--------------------------------------------------------------------===//
+
         public CreateAdd(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFAdd(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateSub(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFSub(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateMul(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFMul(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateSDiv(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateUDiv(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFDiv(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateSRem(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateURem(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFRem(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateAnd(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateOr(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateXor(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateShl(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateAShr(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateLShr(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateNeg(value: Value, name?: string): Value;
+
         public CreateFNeg(value: Value, name?: string): Value;
+
         public CreateNot(value: Value, name?: string): Value;
+
+
+        //===--------------------------------------------------------------------===//
+        // Instruction creation methods: Memory Instructions
+        //===--------------------------------------------------------------------===//
+
+        // customized
         public CreateAlloca(type: Type, arraySize?: Value | null, name?: string): AllocaInst;
+
         public CreateLoad(type: Type, ptr: Value, name?: string): LoadInst;
+
         public CreateStore(value: Value, ptr: Value): StoreInst;
+
         public CreateGEP(type: Type, ptr: Value, idxList: Value[], name?: string): Value;
         public CreateGEP(type: Type, ptr: Value, idx: Value, name?: string): Value;
+
         public CreateInBoundsGEP(type: Type, ptr: Value, idxList: Value[], name?: string): Value;
         public CreateInBoundsGEP(type: Type, ptr: Value, idx: Value, name?: string): Value;
+
         public CreateGlobalStringPtr(str: string, name?: string, addrSpace?: number, module?: Module): Constant;
+
+        //===--------------------------------------------------------------------===//
+        // Instruction creation methods: Cast/Conversion Operators
+        //===--------------------------------------------------------------------===//
+
         public CreateTrunc(value: Value, destType: Type, name?: string): Value;
+
         public CreateZExt(value: Value, destType: Type, name?: string): Value;
+
         public CreateSExt(value: Value, destType: Type, name?: string): Value;
+
         public CreateZExtOrTrunc(value: Value, destType: Type, name?: string): Value;
+
         public CreateSExtOrTrunc(value: Value, destType: Type, name?: string): Value;
+
         public CreateFPToUI(value: Value, destType: Type, name?: string): Value;
+
         public CreateFPToSI(value: Value, destType: Type, name?: string): Value;
+
         public CreateUIToFP(value: Value, destType: Type, name?: string): Value;
+
         public CreateSIToFP(value: Value, destType: Type, name?: string): Value;
+
         public CreateFPTrunc(value: Value, destType: Type, name?: string): Value;
+
         public CreateFPExt(value: Value, destType: Type, name?: string): Value;
+
         public CreatePtrToInt(value: Value, destType: Type, name?: string): Value;
+
         public CreateIntToPtr(value: Value, destType: Type, name?: string): Value;
+
         public CreateBitCast(value: Value, destType: Type, name?: string): Value;
+
         public CreateAddrSpaceCast(value: Value, destType: Type, name?: string): Value;
+
         public CreateZExtOrBitCast(value: Value, destType: Type, name?: string): Value;
+
         public CreateSExtOrBitCast(value: Value, destType: Type, name?: string): Value;
+
         public CreateTruncOrBitCast(value: Value, destType: Type, name?: string): Value;
+
         public CreatePointerCast(value: Value, destType: Type, name?: string): Value;
+
         public CreatePointerBitCastOrAddrSpaceCast(value: Value, destType: Type, name?: string): Value;
+
         public CreateIntCast(value: Value, destType: Type, isSigned: boolean, name?: string): Value;
+
         public CreateBitOrPointerCast(value: Value, destType: Type, name?: string): Value;
+
         public CreateFPCast(value: Value, destType: Type, name?: string): Value;
+
+        //===--------------------------------------------------------------------===//
+        // Instruction creation methods: Compare Instructions
+        //===--------------------------------------------------------------------===//
+
         public CreateICmpEQ(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateICmpNE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateICmpSGE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateICmpSGT(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateICmpSLE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateICmpSLT(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateICmpUGE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateICmpUGT(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateICmpULE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateICmpULT(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpOEQ(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpONE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpOGE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpOGT(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpOLE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpOLT(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpUEQ(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpUNE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpUGE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpUGT(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpULE(lhs: Value, rhs: Value, name?: string): Value;
+
         public CreateFCmpULT(lhs: Value, rhs: Value, name?: string): Value;
+
+
+        //===--------------------------------------------------------------------===//
+        // Instruction creation methods: Other Instructions
+        //===--------------------------------------------------------------------===//
+
         public CreatePHI(type: Type, numReservedValues: number, name?: string): PHINode;
+
+        // customized
         public CreateCall(callee: Function, name?: string): CallInst;
         public CreateCall(callee: Function, args: Value[], name?: string): CallInst;
         public CreateCall(callee: FunctionCallee, name?: string): CallInst;
         public CreateCall(callee: FunctionCallee, args: Value[], name?: string): CallInst;
         public CreateCall(funcType: FunctionType, callee: Value, name?: string): CallInst;
         public CreateCall(funcType: FunctionType, callee: Value, args: Value[], name?: string): CallInst;
+
         public CreateSelect(cond: Value, trueValue: Value, falseValue: Value, name?: string): Value;
+
         public CreateExtractValue(agg: Value, idxs: number[], name?: string): Value;
+
         public CreateInsertValue(agg: Value, value: Value, idxs: number[], name?: string): Value;
+
         public CreateLandingPad(type: Type, numClauses: number, name?: string): LandingPadInst;
+
+        //===--------------------------------------------------------------------===//
+        // Utility creation methods
+        //===--------------------------------------------------------------------===//
+
         public CreateIsNull(value: Value, name?: string): Value;
+
         public CreateIsNotNull(value: Value, name?: string): Value;
+
         public CreatePtrDiff(elemType: Type, lhs: Value, rhs: Value, name?: string): Value;
     }
+
     namespace IRBuilder {
         export class InsertPoint {
             protected constructor();
         }
     }
+
     class Metadata {
         protected constructor();
     }
+
     class MDNode extends Metadata {
         protected constructor();
     }
+
     class DebugLoc {
         public constructor();
     }
+
     class DITypeRefArray {
         protected constructor();
     }
+
     class DINode extends MDNode {
         public static readonly DIFlags: {
             FlagZero: number;
@@ -913,41 +1642,55 @@ declare namespace llvm {
             FlagAccessibility: number;
             FlagPtrToMemberRep: number;
         }
+
         protected constructor();
     }
+
     class DIScope extends DINode {
         protected constructor();
     }
+
     class DIFile extends DIScope {
         protected constructor();
     }
+
     class DIType extends DIScope {
         protected constructor();
     }
+
     class DIBasicType extends DIType {
         protected constructor();
     }
+
     class DIDerivedType extends DIType {
         protected constructor();
     }
+
     class DICompositeType extends DIType {
         protected constructor();
     }
+
     class DISubroutineType extends DIType {
         protected constructor();
     }
+
     class DICompileUnit extends DIScope {
         public getFile(): DIFile;
+
         protected constructor();
     }
+
     class DILocalScope extends DIScope {
         protected constructor();
     }
+
     class DILocation extends MDNode {
         public static get(context: LLVMContext, line: number, column: number, metadata: Metadata): DILocation;
         public static get(context: LLVMContext, line: number, column: number, scope: DILocalScope): DILocation;
+
         protected constructor();
     }
+
     class DISubprogram extends DILocalScope {
         public static readonly DISPFlags: {
             SPFlagZero: number;
@@ -965,56 +1708,86 @@ declare namespace llvm {
             SPFlagNonvirtual: number;
             SPFlagVirtuality: number;
         }
+
         protected constructor();
     }
+
     class DILexicalBlock extends DILocalScope {
         protected constructor();
     }
+
     class DINamespace extends DIScope {
         protected constructor();
     }
+
     class DIVariable extends DINode {
         protected constructor();
     }
+
     class DIExpression extends MDNode {
         protected constructor();
     }
+
     class DIGlobalVariableExpression extends MDNode {
         protected constructor();
     }
+
     class DILocalVariable extends DIVariable {
         protected constructor();
     }
+
     class DIGlobalVariable extends DIVariable {
         protected constructor();
     }
+
     class DIBuilder {
         public constructor(module: Module);
+
         public createFile(filename: string, directory: string): DIFile;
+
         public createCompileUnit(lang: number, file: DIFile, producer: string, isOptimized: boolean, flags: string, rv: number): DICompileUnit;
+
         public createFunction(scope: DIScope, name: string, linkage: string, file: DIFile, line: number, type: DISubroutineType, scopeLine: number, flags: number, spFlags: number): DISubprogram;
+
         public createLexicalBlock(scope: DIScope, file: DIFile, line: number, column: number): DILexicalBlock;
+
         public createBasicType(name: string, sizeInBits: number, encoding: number): DIBasicType;
+
         public getOrCreateTypeArray(elements: (Metadata | null)[]): DITypeRefArray;
+
         public createSubroutineType(paramTypes: DITypeRefArray): DISubroutineType;
+
         public createExpression(): DIExpression;
+
         public createParameterVariable(scope: DIScope, name: string, argNo: number, file: DIFile, line: number, type: DIType, alwaysPreserve?: boolean): DILocalVariable;
+
         public createAutoVariable(scope: DIScope, name: string, file: DIFile, line: number, type: DIType | null, alwaysPreserve?: boolean): DILocalVariable;
+
         public createGlobalVariableExpression(context: DIScope, name: string, linkage: string, file: DIFile, line: number, type: DIType, IsLocalToUnit: boolean): DIGlobalVariableExpression;
+
         public insertDeclare(storage: Value, variable: DILocalVariable, expr: DIExpression, location: DILocation, insertBB: BasicBlock): Instruction;
         public insertDeclare(storage: Value, variable: DILocalVariable, expr: DIExpression, location: DILocation, insertBefore: Instruction): Instruction;
+
         public insertDbgValueIntrinsic(value: Value, variable: DILocalVariable, expr: DIExpression, location: DILocation, insertBB: BasicBlock): Instruction;
         public insertDbgValueIntrinsic(value: Value, variable: DILocalVariable, expr: DIExpression, location: DILocation, insertBefore: Instruction): Instruction;
+
         public finalizeSubprogram(subprogram: DISubprogram): void;
+
         public finalize(): void;
     }
+
     class DataLayout {
         public constructor(desc: string);
+
         public getStringRepresentation(): string;
+
         public getTypeAllocSize(type: Type): number;
     }
+
     function verifyFunction(func: Function): boolean;
+
     function verifyModule(module: Module): boolean;
+
     namespace Intrinsic {
         const abs: number;
         const addressofreturnaddress: number;
@@ -1096,6 +1869,7 @@ declare namespace llvm {
         const expect_with_probability: number;
         const fabs: number;
         const floor: number;
+        const flt_rounds: number;
         const fma: number;
         const fmuladd: number;
         const fptosi_sat: number;
@@ -1320,41 +2094,67 @@ declare namespace llvm {
         const write_register: number;
         const xray_customevent: number;
         const xray_typedevent: number;
+
         function getDeclaration(module: Module, id: number, types?: Type[]): Function;
     }
+
     function parseIRFile(filename: string, err: SMDiagnostic, context: LLVMContext): Module;
+
     class Linker {
         public constructor(module: Module);
+
         public linkInModule(srcModule: Module): boolean;
+
         public static linkModules(destModule: Module, srcModule: Module): boolean;
     }
+
     class Target {
         public createTargetMachine(targetTriple: string, cpu: string, features?: string): TargetMachine;
+
         public getName(): string;
+
         public getShortDescription(): string;
+
         protected constructor();
     }
+
     class TargetRegistry {
         static lookupTarget(target: string): Target | null;
+
         protected constructor();
     }
+
     class SMDiagnostic {
         public constructor();
     }
+
     class TargetMachine {
         public createDataLayout(): DataLayout;
+
         protected constructor();
     }
+
     function InitializeAllTargetInfos(): void;
+
     function InitializeAllTargets(): void;
+
     function InitializeAllTargetMCs(): void;
+
     function InitializeAllAsmPrinters(): void;
+
     function InitializeAllAsmParsers(): void;
+
     function InitializeAllDisassemblers(): void;
+
     function InitializeNativeTarget(): boolean;
+
     function InitializeNativeTargetAsmPrinter(): boolean;
+
     function InitializeNativeTargetAsmParser(): boolean;
+
     function InitializeNativeTargetDisassembler(): boolean;
 }
+
 export = llvm;
+
 export as namespace llvm;

--- a/llvm-bindings.in.d.ts
+++ b/llvm-bindings.in.d.ts
@@ -301,7 +301,7 @@ declare namespace llvm {
 
         public getPrimitiveSizeInBits(): number;
 
-        public getPointerElementType(): Type;
+        public getNonOpaquePointerElementType(): Type;
 
         // extra
         public static isSameType(type1: Type, type2: Type): boolean;
@@ -443,8 +443,10 @@ declare namespace llvm {
         // duplicated
         public getTypeID(): number;
 
-        // duplicated
-        public getPointerElementType(): Type;
+        /**
+         * @deprecated In LLVM 15,16 these are deprecated. LLVM 17 this is removed
+         */
+        public getNonOpaquePointerElementType(): Type;
 
         protected constructor();
     }

--- a/llvm-bindings.in.d.ts
+++ b/llvm-bindings.in.d.ts
@@ -2,15 +2,12 @@ declare namespace llvm {
     class APInt {
         public constructor(numBits: number, value: number, isSigned?: boolean);
     }
-
     class APFloat {
         public constructor(value: number);
     }
-
     namespace LLVMConstants {
         const DEBUG_METADATA_VERSION: number;
     }
-
     namespace dwarf {
         namespace LLVMConstants {
             const DWARF_VERSION: number;
@@ -79,9 +76,7 @@ declare namespace llvm {
             const DW_LANG_hi_user: number;
         }
     }
-
     function WriteBitcodeToFile(module: Module, filename: string): void;
-
     namespace config {
         const LLVM_DEFAULT_TARGET_TRIPLE: string;
         const LLVM_HOST_TRIPLE: string;
@@ -91,11 +86,9 @@ declare namespace llvm {
         const LLVM_VERSION_PATCH: number;
         const LLVM_VERSION_STRING: string;
     }
-
     class LLVMContext {
         public constructor();
     }
-
     class Attribute {
         public static readonly AttrKind: {
 
@@ -105,14 +98,11 @@ declare namespace llvm {
 #include "llvm/IR/Attributes.inc"
 
         };
-
         public static get(context: LLVMContext, kind: number, value?: number): Attribute;
         public static get(context: LLVMContext, kind: string, value?: string): Attribute;
         public static get(context: LLVMContext, kind: number, type: Type): Attribute;
-
         protected constructor();
     }
-
     class Module {
         public static readonly ModFlagBehavior: {
             Error: number;
@@ -125,44 +115,25 @@ declare namespace llvm {
             ModFlagBehaviorFirstVal: number;
             ModFlagBehaviorLastVal: number;
         }
-
         public constructor(moduleID: string, context: LLVMContext);
-
         public getModuleIdentifier(): string;
-
         public getSourceFileName(): string;
-
         public getName(): string;
-
         public getDataLayoutStr(): string;
-
         public getDataLayout(): DataLayout;
-
         public getTargetTriple(): string;
-
         public setModuleIdentifier(moduleID: string): void;
-
         public setSourceFileName(sourceFileName: string): void;
-
         public setDataLayout(desc: string): void;
         public setDataLayout(dataLayout: DataLayout): void;
-
         public setTargetTriple(triple: string): void;
-
         public getFunction(name: string): Function | null;
-
         public getOrInsertFunction(name: string, funcType: FunctionType): FunctionCallee;
-
         public getGlobalVariable(name: string, allowInternal?: boolean): GlobalVariable | null;
-
         public addModuleFlag(behavior: number, key: string, value: number): void;
-
         public empty(): boolean;
-
-        // customized
         public print(): string;
     }
-
     class Type {
         public static readonly TypeID: {
             HalfTyID: number;
@@ -185,308 +156,155 @@ declare namespace llvm {
             FixedVectorTyID: number;
             ScalableVectorTyID: number;
         };
-
         public static getVoidTy(context: LLVMContext): Type;
-
         public static getLabelTy(context: LLVMContext): Type;
-
         public static getHalfTy(context: LLVMContext): Type;
-
         public static getBFloatTy(context: LLVMContext): Type;
-
         public static getFloatTy(context: LLVMContext): Type;
-
         public static getDoubleTy(context: LLVMContext): Type;
-
         public static getMetadataTy(context: LLVMContext): Type;
-
         public static getX86_FP80Ty(context: LLVMContext): Type;
-
         public static getFP128Ty(context: LLVMContext): Type;
-
         public static getPPC_FP128Ty(context: LLVMContext): Type;
-
         public static getX86_MMXTy(context: LLVMContext): Type;
-
         public static getTokenTy(context: LLVMContext): Type;
-
         public static getIntNTy(context: LLVMContext, numBits: number): IntegerType;
-
         public static getInt1Ty(context: LLVMContext): IntegerType;
-
         public static getInt8Ty(context: LLVMContext): IntegerType;
-
         public static getInt16Ty(context: LLVMContext): IntegerType;
-
         public static getInt32Ty(context: LLVMContext): IntegerType;
-
         public static getInt64Ty(context: LLVMContext): IntegerType;
-
         public static getInt128Ty(context: LLVMContext): IntegerType;
-
         public static getHalfPtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getBFloatPtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getFloatPtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getDoublePtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getX86_FP80PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getFP128PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getPPC_FP128PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getX86_MMXPtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getInt1PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getInt8PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getInt16PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getInt32PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public static getInt64PtrTy(context: LLVMContext, addrSpace?: number): PointerType;
-
         public getTypeID(): number;
-
         public isVoidTy(): boolean;
-
         public isHalfTy(): boolean;
-
         public isBFloatTy(): boolean;
-
         public isFloatTy(): boolean;
-
         public isDoubleTy(): boolean;
-
         public isX86_FP80Ty(): boolean;
-
         public isFP128Ty(): boolean;
-
         public isPPC_FP128Ty(): boolean;
-
         public isFloatingPointTy(): boolean;
-
         public isX86_MMXTy(): boolean;
-
         public isLabelTy(): boolean;
-
         public isMetadataTy(): boolean;
-
         public isTokenTy(): boolean;
-
         public isIntegerTy(bitWidth?: number): boolean;
-
         public isFunctionTy(): boolean;
-
         public isStructTy(): boolean;
-
         public isArrayTy(): boolean;
-
         public isPointerTy(): boolean;
-
         public isVectorTy(): boolean;
-
         public isEmptyTy(): boolean;
-
         public isFirstClassType(): boolean;
-
         public isSingleValueType(): boolean;
-
         public isAggregateType(): boolean;
-
         public getPointerTo(addrSpace?: number): PointerType;
-
         public getPrimitiveSizeInBits(): number;
-
         public getPointerElementType(): Type;
-
-        // extra
         public static isSameType(type1: Type, type2: Type): boolean;
-
         protected constructor();
     }
-
     class IntegerType extends Type {
         public static get(context: LLVMContext, numBits: number): IntegerType;
-
-        // duplicated
         public isStructTy(): boolean;
-
-        // duplicated
         public isIntegerTy(bitWidth?: number): boolean;
-
-        // duplicated
         public isVoidTy(): boolean;
-
-        // duplicated
         public getTypeID(): number;
-
         protected constructor();
     }
-
     class FunctionType extends Type {
         public static get(returnType: Type, isVarArg: boolean): FunctionType;
         public static get(returnType: Type, paramTypes: Type[], isVarArg: boolean): FunctionType;
-
-        // duplicated
         public isVoidTy(): boolean;
-
-        // duplicated
         public getTypeID(): number;
-
         protected constructor();
     }
-
     class FunctionCallee {
         public getFunctionType(): FunctionType;
-
         public getCallee(): Value;
-
         protected constructor();
     }
-
     class StructType extends Type {
         public static create(context: LLVMContext, name: string): StructType;
         public static create(context: LLVMContext, elementTypes: Type[], name: string): StructType;
-
         public static get(context: LLVMContext): StructType;
         public static get(context: LLVMContext, elementTypes: Type[]): StructType;
-
         public getTypeByName(name: string): StructType | null;
-
         public setBody(elementTypes: Type[]): void;
-
         public setName(name: string): void;
-
         public hasName(): boolean;
-
         public getName(): string;
-
         public isOpaque(): boolean;
-
         public isPacked(): boolean;
-
         public isLiteral(): boolean;
-
-        // duplicated
         public getPointerTo(addrSpace?: number): PointerType;
-
-        // duplicated
         public isStructTy(): boolean;
-
-        // duplicated
         public isIntegerTy(bitWidth?: number): boolean;
-
-        // duplicated
         public isVoidTy(): boolean;
-
-        // duplicated
         public getTypeID(): number;
-
         protected constructor();
     }
-
     class ArrayType extends Type {
         public static get(elemType: Type, numElements: number): ArrayType;
-
         public static isValidElementType(elemType: Type): boolean;
-
         public getNumElements(): number;
-
         public getElementType(): Type;
-
-        // duplicated
         public isStructTy(): boolean;
-
-        // duplicated
         public isVoidTy(): boolean;
-
-        // duplicated
         public getTypeID(): number;
-
         protected constructor();
     }
-
     class VectorType extends Type {
-        // duplicated
         public isStructTy(): boolean;
-
-        // duplicated
         public isVoidTy(): boolean;
-
-        // duplicated
         public getTypeID(): number;
-
         protected constructor();
     }
-
     class PointerType extends Type {
         public static get(elementType: Type, addrSpace: number): PointerType;
-
         public static getUnqual(elementType: Type): PointerType;
-
-        // duplicated
         public isPointerTy(): boolean;
-
-        // duplicated
         public isStructTy(): boolean;
-
-        // duplicated
         public isIntegerTy(bitWidth?: number): boolean;
-
-        // duplicated
         public isVoidTy(): boolean;
-
-        // duplicated
         public getTypeID(): number;
-
-        // duplicated
         public getPointerElementType(): Type;
-
         protected constructor();
     }
-
     class Value {
         public static MaxAlignmentExponent: number;
         public static MaximumAlignment: number;
-
         public getType(): Type;
-
         public hasName(): boolean;
-
         public getName(): string;
-
         public setName(name: string): void;
-
         public deleteValue(): void;
-
         public replaceAllUsesWith(newValue: Value): void;
-
         public use_empty(): boolean;
-
         public user_empty(): boolean;
-
         protected constructor();
     }
-
     class Argument extends Value {
         public constructor(type: Type, name?: string, func?: Function, argNo?: number);
-
         public getParent(): Function;
-
         public getArgNo(): number;
-
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setName(name: string): void;
     }
-
     class BasicBlock extends Value {
         public static Create(
             context: LLVMContext,
@@ -494,145 +312,84 @@ declare namespace llvm {
             parent?: Function,
             insertBefore?: BasicBlock
         ): BasicBlock;
-
         public getParent(): Function | null;
-
         public getModule(): Module | null;
-
         public getTerminator(): Instruction | null;
-
         public getFirstNonPHI(): Instruction | null;
-
         public insertInto(parent: Function, insertBefore?: BasicBlock): void;
-
         public removeFromParent(): void;
-
-        // customized
         public eraseFromParent(): void;
-
-        // duplicated
         public use_empty(): boolean;
-
-        // duplicated
         public getType(): Type;
-
-        // extra
         public deleteSelf(): void;
-
         protected constructor();
     }
-
     class User extends Value {
         public getOperand(i: number): Value;
-
         public setOperand(i: number, value: Value): void;
-
         public getNumOperands(): number;
-
-        // duplicated
         public getType(): Type;
-
         protected constructor();
     }
-
     class Constant extends User {
         public static getNullValue(type: Type): Constant;
-
         public static getAllOnesValue(type: Type): Constant;
-
         public isNullValue(): boolean;
-
         public isOneValue(): boolean;
-
         public isAllOnesValue(): boolean;
-
-        // duplicated
         public getType(): Type;
-
         protected constructor();
     }
-
     class ConstantInt extends Constant {
         public static get(context: LLVMContext, value: APInt): ConstantInt;
         public static get(type: IntegerType, value: number, isSigned?: boolean): ConstantInt;
         public static get(type: Type, value: APInt): Constant;
         public static get(type: Type, value: number, isSigned?: boolean): Constant;
-
         public static getTrue(context: LLVMContext): ConstantInt;
-
         public static getFalse(context: LLVMContext): ConstantInt;
-
         public getType(): IntegerType;
-
         protected constructor();
     }
-
     class ConstantFP extends Constant {
         public static get(type: Type, value: number): Constant;
         public static get(type: Type, value: APFloat): Constant;
         public static get(type: Type, value: string): Constant;
         public static get(context: LLVMContext, value: APFloat): ConstantFP;
-
         public static getNaN(type: Type): Constant
-
-        // duplicated
         public getType(): Type;
-
         protected constructor();
     }
-
     class ConstantArray extends Constant {
         public static get(type: ArrayType, values: Constant[]): Constant;
-
         public getType(): ArrayType;
-
         protected constructor();
     }
-
     class ConstantStruct extends Constant {
         public static get(type: StructType, values: Constant[]): Constant;
-
         public getType(): StructType;
-
         protected constructor();
     }
-
     class ConstantPointerNull extends Constant {
         public static get(type: PointerType): ConstantPointerNull;
-
         public getType(): PointerType;
-
         protected constructor();
     }
-
     class ConstantDataArray extends Constant {
         public static get(context: LLVMContext, elements: number[]): Constant;
-
         public static getString(context: LLVMContext, initializer: string, addNull?: boolean): Constant;
-
         public getType(): ArrayType;
-
         protected constructor();
     }
-
     class ConstantExpr extends Constant {
         public static getBitCast(constant: Constant, type: Type): Constant;
-
-        // duplicated
         public getType(): Type;
-
         protected constructor();
     }
-
     class UndefValue extends Constant {
         public static get(type: Type): UndefValue;
-
-        // duplicated
         public getType(): Type;
-
         protected constructor();
     }
-
     class GlobalValue extends Constant {
         public static readonly LinkageTypes: {
             ExternalLinkage: number;
@@ -652,959 +409,472 @@ declare namespace llvm {
             HiddenVisibility: number;
             ProtectedVisibility: number;
         }
-
-        // duplicated
         public getType(): PointerType;
-
         public getValueType(): Type;
-
         protected constructor();
     }
-
     class GlobalObject extends GlobalValue {
-        // duplicated
         public getType(): PointerType;
-
-        // duplicated
         public getValueType(): Type;
-
         protected constructor();
     }
-
     class GlobalVariable extends GlobalObject {
-        // customized
         public constructor(type: Type, isConstant: boolean, linkage: number, initializer?: Constant | null, name?: string);
-        // customized
         public constructor(module: Module, type: Type, isConstant: boolean, linkage: number, initializer: Constant | null, name?: string);
-
-        // duplicated
         public getType(): PointerType;
-
-        // duplicated
         public getValueType(): Type;
-
         public setInitializer(initVal: Constant | null): void;
-
         public removeFromParent(): void;
-
         public eraseFromParent(): void;
-
         public addDebugInfo(gv: DIGlobalVariableExpression): void;
     }
-
     class Function extends GlobalObject {
         public static Create(funcType: FunctionType, linkage: number, name?: string, module?: Module): Function;
-
         public arg_size(): number;
-
         public getArg(i: number): Argument;
-
         public getReturnType(): Type;
-
-        // customized
         public addBasicBlock(basicBlock: BasicBlock): void;
-
         public getEntryBlock(): BasicBlock;
-
-        // extra
         public getExitBlock(): BasicBlock;
-
-        // customized
         public insertAfter(where: BasicBlock, basicBlock: BasicBlock): void;
-
         public deleteBody(): void;
-
         public removeFromParent(): void;
-
         public eraseFromParent(): void;
-
-        // duplicated
         public use_empty(): boolean;
-
-        // duplicated
         public user_empty(): boolean;
-
-        // duplicated
         public getNumUses(): number;
-
-        // duplicated
         public removeDeadConstantUsers(): void;
-
         public hasPersonalityFn(): boolean;
-
         public setPersonalityFn(fn: Constant): void;
-
         public setDoesNotThrow(): void;
-
         public setSubprogram(subprogram: DISubprogram): void;
-
         public getSubprogram(): DISubprogram;
-
-        // duplicated
         public getType(): PointerType;
-
         public addFnAttr(kind: number): void;
         public addFnAttr(attr: Attribute): void;
-
         public addParamAttr(argNo: number, kind: number): void;
         public addParamAttr(argNo: number, attr: Attribute): void;
-
         public addRetAttr(kind: number): void;
         public addRetAttr(attr: Attribute): void;
-
         protected constructor();
     }
-
     class Instruction extends User {
         public user_back(): Instruction | null;
-
         public getParent(): BasicBlock | null;
-
         public getModule(): Module | null;
-
         public getFunction(): Function | null;
-
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class AllocaInst extends Instruction {
         public getAllocatedType(): Type;
-
         public getArraySize(): Value;
-
-        // duplicated
         public getType(): PointerType;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class LoadInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class StoreInst extends Instruction {
         public getValueOperand(): Value;
-
         public getPointerOperand(): Value;
-
         public getPointerOperandType(): Type;
-
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class FenceInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class AtomicCmpXchgInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class AtomicRMWInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class GetElementPtrInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class ICmpInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class FCmpInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class CallInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class SelectInst extends Instruction {
         public getCondition(): Value;
-
         public getTrueValue(): Value;
-
         public getFalseValue(): Value;
-
         public setCondition(value: Value): void;
-
         public setTrueValue(value: Value): void;
-
         public setFalseValue(value: Value): void;
-
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class VAArgInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class ExtractElementInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class InsertElementInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class ShuffleVectorInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class ExtractValueInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class InsertValueInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class PHINode extends Instruction {
         public addIncoming(value: Value, basicBlock: BasicBlock): void;
-
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class LandingPadInst extends Instruction {
         public setCleanup(value: boolean): void;
-
         public addClause(clauseVal: Constant): void;
-
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class ReturnInst extends Instruction {
         public getReturnValue(): Value;
-
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class BranchInst extends Instruction {
         public isUnconditional(): boolean;
-
         public isConditional(): boolean;
-
         public getCondition(): Value;
-
         public getNumSuccessors(): number;
-
         public getSuccessor(i: number): BasicBlock;
-
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class SwitchInst extends Instruction {
         public addCase(onVal: ConstantInt, dest: BasicBlock): void;
-
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class IndirectBrInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class InvokeInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class CallBrInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class ResumeInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class CatchSwitchInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class CleanupPadInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class CatchPadInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class CatchReturnInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class CleanupReturnInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class UnreachableInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class TruncInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class ZExtInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class SExtInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class FPTruncInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class FPExtInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class UIToFPInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class SIToFPInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class FPToUIInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class FPToSIInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class IntToPtrInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class PtrToIntInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class BitCastInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class AddrSpaceCastInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class FreezeInst extends Instruction {
-        // duplicated
         public getType(): Type;
-
-        // duplicated
         public setDebugLoc(location: DebugLoc): void;
-
         protected constructor();
     }
-
     class IRBuilder {
         public constructor(context: LLVMContext);
         public constructor(theBB: BasicBlock);
         public constructor(ip: Instruction);
-
-        //===--------------------------------------------------------------------===//
-        // Builder configuration methods
-        //===--------------------------------------------------------------------===//
-
         public ClearInsertionPoint(): void;
-
         public GetInsertBlock(): BasicBlock | null;
-
         public SetInsertPoint(basicBlock: BasicBlock): void;
         public SetInsertPoint(inst: Instruction): void;
-
         public saveIP(): IRBuilder.InsertPoint;
-
         public saveAndClearIP(): IRBuilder.InsertPoint;
-
         public restoreIP(ip: IRBuilder.InsertPoint): void;
-
         public SetCurrentDebugLocation(location: DebugLoc): void;
-        // extra
         public SetCurrentDebugLocation(location: DILocation): void;
-
-        //===--------------------------------------------------------------------===//
-        // Miscellaneous creation methods.
-        //===--------------------------------------------------------------------===//
-
         public CreateGlobalString(str: string, name?: string, addrSpace?: number, module?: Module): GlobalVariable;
-
         public getInt1(value: boolean): ConstantInt;
-
         public getTrue(): ConstantInt;
-
         public getFalse(): ConstantInt;
-
         public getInt8(value: number): ConstantInt;
-
         public getInt16(value: number): ConstantInt;
-
         public getInt32(value: number): ConstantInt;
-
         public getInt64(value: number): ConstantInt;
-
         public getIntN(numBits: number, value: number): ConstantInt;
-
         public getInt(value: APInt): ConstantInt;
-
-        //===--------------------------------------------------------------------===//
-        // Type creation methods
-        //===--------------------------------------------------------------------===//
-
         public getInt1Ty(): IntegerType;
-
         public getInt8Ty(): IntegerType;
-
         public getInt16Ty(): IntegerType;
-
         public getInt32Ty(): IntegerType;
-
         public getInt64Ty(): IntegerType;
-
         public getInt128Ty(): IntegerType;
-
         public getIntNTy(numBits: number): IntegerType;
-
         public getHalfTy(): Type;
-
         public getBFloatTy(): Type;
-
         public getFloatTy(): Type;
-
         public getDoubleTy(): Type;
-
         public getVoidTy(): Type;
-
         public getInt8PtrTy(addrSpace?: number): PointerType;
-
         public getIntPtrTy(dataLayout: DataLayout, addrSpace?: number): IntegerType;
-
-        //===--------------------------------------------------------------------===//
-        // Instruction creation methods: Terminators
-        //===--------------------------------------------------------------------===//
-
         public CreateRetVoid(): ReturnInst;
-
         public CreateRet(value: Value): ReturnInst;
-
         public CreateBr(destBB: BasicBlock): BranchInst;
-
         public CreateCondBr(cond: Value, thenBB: BasicBlock, elseBB: BasicBlock): BranchInst;
-
         public CreateSwitch(value: Value, dest: BasicBlock, numCases?: number): SwitchInst;
-
         public CreateIndirectBr(addr: Value, numDests?: number): IndirectBrInst;
-
-        // customized
         public CreateInvoke(callee: Function, normalDest: BasicBlock, unwindDest: BasicBlock, name?: string): InvokeInst;
         public CreateInvoke(callee: Function, normalDest: BasicBlock, unwindDest: BasicBlock, args: Value[], name?: string): InvokeInst;
         public CreateInvoke(callee: FunctionCallee, normalDest: BasicBlock, unwindDest: BasicBlock, name?: string): InvokeInst;
         public CreateInvoke(callee: FunctionCallee, normalDest: BasicBlock, unwindDest: BasicBlock, args: Value[], name?: string): InvokeInst;
         public CreateInvoke(funcType: FunctionType, callee: Function, normalDest: BasicBlock, unwindDest: BasicBlock, name?: string): InvokeInst;
         public CreateInvoke(funcType: FunctionType, callee: Function, normalDest: BasicBlock, unwindDest: BasicBlock, args: Value[], name?: string): InvokeInst;
-
         public CreateResume(exn: Value): ResumeInst;
-
         public CreateUnreachable(): UnreachableInst;
-
-        //===--------------------------------------------------------------------===//
-        // Instruction creation methods: Binary Operators
-        //===--------------------------------------------------------------------===//
-
         public CreateAdd(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFAdd(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateSub(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFSub(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateMul(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFMul(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateSDiv(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateUDiv(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFDiv(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateSRem(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateURem(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFRem(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateAnd(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateOr(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateXor(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateShl(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateAShr(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateLShr(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateNeg(value: Value, name?: string): Value;
-
         public CreateFNeg(value: Value, name?: string): Value;
-
         public CreateNot(value: Value, name?: string): Value;
-
-
-        //===--------------------------------------------------------------------===//
-        // Instruction creation methods: Memory Instructions
-        //===--------------------------------------------------------------------===//
-
-        // customized
         public CreateAlloca(type: Type, arraySize?: Value | null, name?: string): AllocaInst;
-
         public CreateLoad(type: Type, ptr: Value, name?: string): LoadInst;
-
         public CreateStore(value: Value, ptr: Value): StoreInst;
-
         public CreateGEP(type: Type, ptr: Value, idxList: Value[], name?: string): Value;
         public CreateGEP(type: Type, ptr: Value, idx: Value, name?: string): Value;
-
         public CreateInBoundsGEP(type: Type, ptr: Value, idxList: Value[], name?: string): Value;
         public CreateInBoundsGEP(type: Type, ptr: Value, idx: Value, name?: string): Value;
-
         public CreateGlobalStringPtr(str: string, name?: string, addrSpace?: number, module?: Module): Constant;
-
-        //===--------------------------------------------------------------------===//
-        // Instruction creation methods: Cast/Conversion Operators
-        //===--------------------------------------------------------------------===//
-
         public CreateTrunc(value: Value, destType: Type, name?: string): Value;
-
         public CreateZExt(value: Value, destType: Type, name?: string): Value;
-
         public CreateSExt(value: Value, destType: Type, name?: string): Value;
-
         public CreateZExtOrTrunc(value: Value, destType: Type, name?: string): Value;
-
         public CreateSExtOrTrunc(value: Value, destType: Type, name?: string): Value;
-
         public CreateFPToUI(value: Value, destType: Type, name?: string): Value;
-
         public CreateFPToSI(value: Value, destType: Type, name?: string): Value;
-
         public CreateUIToFP(value: Value, destType: Type, name?: string): Value;
-
         public CreateSIToFP(value: Value, destType: Type, name?: string): Value;
-
         public CreateFPTrunc(value: Value, destType: Type, name?: string): Value;
-
         public CreateFPExt(value: Value, destType: Type, name?: string): Value;
-
         public CreatePtrToInt(value: Value, destType: Type, name?: string): Value;
-
         public CreateIntToPtr(value: Value, destType: Type, name?: string): Value;
-
         public CreateBitCast(value: Value, destType: Type, name?: string): Value;
-
         public CreateAddrSpaceCast(value: Value, destType: Type, name?: string): Value;
-
         public CreateZExtOrBitCast(value: Value, destType: Type, name?: string): Value;
-
         public CreateSExtOrBitCast(value: Value, destType: Type, name?: string): Value;
-
         public CreateTruncOrBitCast(value: Value, destType: Type, name?: string): Value;
-
         public CreatePointerCast(value: Value, destType: Type, name?: string): Value;
-
         public CreatePointerBitCastOrAddrSpaceCast(value: Value, destType: Type, name?: string): Value;
-
         public CreateIntCast(value: Value, destType: Type, isSigned: boolean, name?: string): Value;
-
         public CreateBitOrPointerCast(value: Value, destType: Type, name?: string): Value;
-
         public CreateFPCast(value: Value, destType: Type, name?: string): Value;
-
-        //===--------------------------------------------------------------------===//
-        // Instruction creation methods: Compare Instructions
-        //===--------------------------------------------------------------------===//
-
         public CreateICmpEQ(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateICmpNE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateICmpSGE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateICmpSGT(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateICmpSLE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateICmpSLT(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateICmpUGE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateICmpUGT(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateICmpULE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateICmpULT(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpOEQ(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpONE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpOGE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpOGT(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpOLE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpOLT(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpUEQ(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpUNE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpUGE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpUGT(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpULE(lhs: Value, rhs: Value, name?: string): Value;
-
         public CreateFCmpULT(lhs: Value, rhs: Value, name?: string): Value;
-
-
-        //===--------------------------------------------------------------------===//
-        // Instruction creation methods: Other Instructions
-        //===--------------------------------------------------------------------===//
-
         public CreatePHI(type: Type, numReservedValues: number, name?: string): PHINode;
-
-        // customized
         public CreateCall(callee: Function, name?: string): CallInst;
         public CreateCall(callee: Function, args: Value[], name?: string): CallInst;
         public CreateCall(callee: FunctionCallee, name?: string): CallInst;
         public CreateCall(callee: FunctionCallee, args: Value[], name?: string): CallInst;
         public CreateCall(funcType: FunctionType, callee: Value, name?: string): CallInst;
         public CreateCall(funcType: FunctionType, callee: Value, args: Value[], name?: string): CallInst;
-
         public CreateSelect(cond: Value, trueValue: Value, falseValue: Value, name?: string): Value;
-
         public CreateExtractValue(agg: Value, idxs: number[], name?: string): Value;
-
         public CreateInsertValue(agg: Value, value: Value, idxs: number[], name?: string): Value;
-
         public CreateLandingPad(type: Type, numClauses: number, name?: string): LandingPadInst;
-
-        //===--------------------------------------------------------------------===//
-        // Utility creation methods
-        //===--------------------------------------------------------------------===//
-
         public CreateIsNull(value: Value, name?: string): Value;
-
         public CreateIsNotNull(value: Value, name?: string): Value;
-
         public CreatePtrDiff(elemType: Type, lhs: Value, rhs: Value, name?: string): Value;
     }
-
     namespace IRBuilder {
         export class InsertPoint {
             protected constructor();
         }
     }
-
     class Metadata {
         protected constructor();
     }
-
     class MDNode extends Metadata {
         protected constructor();
     }
-
     class DebugLoc {
         public constructor();
     }
-
     class DITypeRefArray {
         protected constructor();
     }
-
     class DINode extends MDNode {
         public static readonly DIFlags: {
             FlagZero: number;
@@ -1643,55 +913,41 @@ declare namespace llvm {
             FlagAccessibility: number;
             FlagPtrToMemberRep: number;
         }
-
         protected constructor();
     }
-
     class DIScope extends DINode {
         protected constructor();
     }
-
     class DIFile extends DIScope {
         protected constructor();
     }
-
     class DIType extends DIScope {
         protected constructor();
     }
-
     class DIBasicType extends DIType {
         protected constructor();
     }
-
     class DIDerivedType extends DIType {
         protected constructor();
     }
-
     class DICompositeType extends DIType {
         protected constructor();
     }
-
     class DISubroutineType extends DIType {
         protected constructor();
     }
-
     class DICompileUnit extends DIScope {
         public getFile(): DIFile;
-
         protected constructor();
     }
-
     class DILocalScope extends DIScope {
         protected constructor();
     }
-
     class DILocation extends MDNode {
         public static get(context: LLVMContext, line: number, column: number, metadata: Metadata): DILocation;
         public static get(context: LLVMContext, line: number, column: number, scope: DILocalScope): DILocation;
-
         protected constructor();
     }
-
     class DISubprogram extends DILocalScope {
         public static readonly DISPFlags: {
             SPFlagZero: number;
@@ -1709,86 +965,56 @@ declare namespace llvm {
             SPFlagNonvirtual: number;
             SPFlagVirtuality: number;
         }
-
         protected constructor();
     }
-
     class DILexicalBlock extends DILocalScope {
         protected constructor();
     }
-
     class DINamespace extends DIScope {
         protected constructor();
     }
-
     class DIVariable extends DINode {
         protected constructor();
     }
-
     class DIExpression extends MDNode {
         protected constructor();
     }
-
     class DIGlobalVariableExpression extends MDNode {
         protected constructor();
     }
-
     class DILocalVariable extends DIVariable {
         protected constructor();
     }
-
     class DIGlobalVariable extends DIVariable {
         protected constructor();
     }
-
     class DIBuilder {
         public constructor(module: Module);
-
         public createFile(filename: string, directory: string): DIFile;
-
         public createCompileUnit(lang: number, file: DIFile, producer: string, isOptimized: boolean, flags: string, rv: number): DICompileUnit;
-
         public createFunction(scope: DIScope, name: string, linkage: string, file: DIFile, line: number, type: DISubroutineType, scopeLine: number, flags: number, spFlags: number): DISubprogram;
-
         public createLexicalBlock(scope: DIScope, file: DIFile, line: number, column: number): DILexicalBlock;
-
         public createBasicType(name: string, sizeInBits: number, encoding: number): DIBasicType;
-
         public getOrCreateTypeArray(elements: (Metadata | null)[]): DITypeRefArray;
-
         public createSubroutineType(paramTypes: DITypeRefArray): DISubroutineType;
-
         public createExpression(): DIExpression;
-
         public createParameterVariable(scope: DIScope, name: string, argNo: number, file: DIFile, line: number, type: DIType, alwaysPreserve?: boolean): DILocalVariable;
-
         public createAutoVariable(scope: DIScope, name: string, file: DIFile, line: number, type: DIType | null, alwaysPreserve?: boolean): DILocalVariable;
-
         public createGlobalVariableExpression(context: DIScope, name: string, linkage: string, file: DIFile, line: number, type: DIType, IsLocalToUnit: boolean): DIGlobalVariableExpression;
-
         public insertDeclare(storage: Value, variable: DILocalVariable, expr: DIExpression, location: DILocation, insertBB: BasicBlock): Instruction;
         public insertDeclare(storage: Value, variable: DILocalVariable, expr: DIExpression, location: DILocation, insertBefore: Instruction): Instruction;
-
         public insertDbgValueIntrinsic(value: Value, variable: DILocalVariable, expr: DIExpression, location: DILocation, insertBB: BasicBlock): Instruction;
         public insertDbgValueIntrinsic(value: Value, variable: DILocalVariable, expr: DIExpression, location: DILocation, insertBefore: Instruction): Instruction;
-
         public finalizeSubprogram(subprogram: DISubprogram): void;
-
         public finalize(): void;
     }
-
     class DataLayout {
         public constructor(desc: string);
-
         public getStringRepresentation(): string;
-
         public getTypeAllocSize(type: Type): number;
     }
-
     function verifyFunction(func: Function): boolean;
-
     function verifyModule(module: Module): boolean;
-
     namespace Intrinsic {
         const abs: number;
         const addressofreturnaddress: number;
@@ -2094,67 +1320,41 @@ declare namespace llvm {
         const write_register: number;
         const xray_customevent: number;
         const xray_typedevent: number;
-
         function getDeclaration(module: Module, id: number, types?: Type[]): Function;
     }
-
     function parseIRFile(filename: string, err: SMDiagnostic, context: LLVMContext): Module;
-
     class Linker {
         public constructor(module: Module);
-
         public linkInModule(srcModule: Module): boolean;
-
         public static linkModules(destModule: Module, srcModule: Module): boolean;
     }
-
     class Target {
         public createTargetMachine(targetTriple: string, cpu: string, features?: string): TargetMachine;
-
         public getName(): string;
-
         public getShortDescription(): string;
-
         protected constructor();
     }
-
     class TargetRegistry {
         static lookupTarget(target: string): Target | null;
-
         protected constructor();
     }
-
     class SMDiagnostic {
         public constructor();
     }
-
     class TargetMachine {
         public createDataLayout(): DataLayout;
-
         protected constructor();
     }
-
     function InitializeAllTargetInfos(): void;
-
     function InitializeAllTargets(): void;
-
     function InitializeAllTargetMCs(): void;
-
     function InitializeAllAsmPrinters(): void;
-
     function InitializeAllAsmParsers(): void;
-
     function InitializeAllDisassemblers(): void;
-
     function InitializeNativeTarget(): boolean;
-
     function InitializeNativeTargetAsmPrinter(): boolean;
-
     function InitializeNativeTargetAsmParser(): boolean;
-
     function InitializeNativeTargetDisassembler(): boolean;
 }
-
 export = llvm;
-
 export as namespace llvm;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "llvm-bindings",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "description": "LLVM bindings for Node.js/JavaScript/TypeScript",
     "keywords": [
         "llvm",

--- a/src/IR/Attributes.cpp
+++ b/src/IR/Attributes.cpp
@@ -6,7 +6,8 @@ void Attribute::Init(Napi::Env env, Napi::Object &exports) {
 
     Napi::Object attributeKinds = Napi::Object::New(env);
 
-#define ATTRIBUTE_ENUM(EnumName, lower) attributeKinds.Set(#EnumName, Napi::Number::New(env, llvm::Attribute::AttrKind::##EnumName));
+#define GET_ATTR_NAMES
+#define ATTRIBUTE_ENUM(EnumName, lower) attributeKinds.Set(#EnumName, Napi::Number::New(env, llvm::Attribute::AttrKind::EnumName));
 #include "llvm/IR/Attributes.inc"
 
     Napi::Function func = DefineClass(env, "Attribute", {

--- a/src/IR/Attributes.cpp
+++ b/src/IR/Attributes.cpp
@@ -5,88 +5,9 @@ void Attribute::Init(Napi::Env env, Napi::Object &exports) {
     Napi::HandleScope scope(env);
 
     Napi::Object attributeKinds = Napi::Object::New(env);
-    attributeKinds.Set("AlwaysInline", Napi::Number::New(env, llvm::Attribute::AttrKind::AlwaysInline));
-    attributeKinds.Set("ArgMemOnly", Napi::Number::New(env, llvm::Attribute::AttrKind::ArgMemOnly));
-    attributeKinds.Set("Builtin", Napi::Number::New(env, llvm::Attribute::AttrKind::Builtin));
-    attributeKinds.Set("Cold", Napi::Number::New(env, llvm::Attribute::AttrKind::Cold));
-    attributeKinds.Set("Convergent", Napi::Number::New(env, llvm::Attribute::AttrKind::Convergent));
-    attributeKinds.Set("DisableSanitizerInstrumentation",
-                       Napi::Number::New(env, llvm::Attribute::AttrKind::DisableSanitizerInstrumentation));
-    attributeKinds.Set("Hot", Napi::Number::New(env, llvm::Attribute::AttrKind::Hot));
-    attributeKinds.Set("ImmArg", Napi::Number::New(env, llvm::Attribute::AttrKind::ImmArg));
-    attributeKinds.Set("InReg", Napi::Number::New(env, llvm::Attribute::AttrKind::InReg));
-    attributeKinds.Set("InaccessibleMemOnly", Napi::Number::New(env, llvm::Attribute::AttrKind::InaccessibleMemOnly));
-    attributeKinds.Set("InaccessibleMemOrArgMemOnly",
-                       Napi::Number::New(env, llvm::Attribute::AttrKind::InaccessibleMemOrArgMemOnly));
-    attributeKinds.Set("InlineHint", Napi::Number::New(env, llvm::Attribute::AttrKind::InlineHint));
-    attributeKinds.Set("JumpTable", Napi::Number::New(env, llvm::Attribute::AttrKind::JumpTable));
-    attributeKinds.Set("MinSize", Napi::Number::New(env, llvm::Attribute::AttrKind::MinSize));
-    attributeKinds.Set("MustProgress", Napi::Number::New(env, llvm::Attribute::AttrKind::MustProgress));
-    attributeKinds.Set("Naked", Napi::Number::New(env, llvm::Attribute::AttrKind::Naked));
-    attributeKinds.Set("Nest", Napi::Number::New(env, llvm::Attribute::AttrKind::Nest));
-    attributeKinds.Set("NoAlias", Napi::Number::New(env, llvm::Attribute::AttrKind::NoAlias));
-    attributeKinds.Set("NoBuiltin", Napi::Number::New(env, llvm::Attribute::AttrKind::NoBuiltin));
-    attributeKinds.Set("NoCallback", Napi::Number::New(env, llvm::Attribute::AttrKind::NoCallback));
-    attributeKinds.Set("NoCapture", Napi::Number::New(env, llvm::Attribute::AttrKind::NoCapture));
-    attributeKinds.Set("NoCfCheck", Napi::Number::New(env, llvm::Attribute::AttrKind::NoCfCheck));
-    attributeKinds.Set("NoDuplicate", Napi::Number::New(env, llvm::Attribute::AttrKind::NoDuplicate));
-    attributeKinds.Set("NoFree", Napi::Number::New(env, llvm::Attribute::AttrKind::NoFree));
-    attributeKinds.Set("NoImplicitFloat", Napi::Number::New(env, llvm::Attribute::AttrKind::NoImplicitFloat));
-    attributeKinds.Set("NoInline", Napi::Number::New(env, llvm::Attribute::AttrKind::NoInline));
-    attributeKinds.Set("NoMerge", Napi::Number::New(env, llvm::Attribute::AttrKind::NoMerge));
-    attributeKinds.Set("NoProfile", Napi::Number::New(env, llvm::Attribute::AttrKind::NoProfile));
-    attributeKinds.Set("NoRecurse", Napi::Number::New(env, llvm::Attribute::AttrKind::NoRecurse));
-    attributeKinds.Set("NoRedZone", Napi::Number::New(env, llvm::Attribute::AttrKind::NoRedZone));
-    attributeKinds.Set("NoReturn", Napi::Number::New(env, llvm::Attribute::AttrKind::NoReturn));
-    attributeKinds.Set("NoSanitizeCoverage", Napi::Number::New(env, llvm::Attribute::AttrKind::NoSanitizeCoverage));
-    attributeKinds.Set("NoSync", Napi::Number::New(env, llvm::Attribute::AttrKind::NoSync));
-    attributeKinds.Set("NoUndef", Napi::Number::New(env, llvm::Attribute::AttrKind::NoUndef));
-    attributeKinds.Set("NoUnwind", Napi::Number::New(env, llvm::Attribute::AttrKind::NoUnwind));
-    attributeKinds.Set("NonLazyBind", Napi::Number::New(env, llvm::Attribute::AttrKind::NonLazyBind));
-    attributeKinds.Set("NonNull", Napi::Number::New(env, llvm::Attribute::AttrKind::NonNull));
-    attributeKinds.Set("NullPointerIsValid", Napi::Number::New(env, llvm::Attribute::AttrKind::NullPointerIsValid));
-    attributeKinds.Set("OptForFuzzing", Napi::Number::New(env, llvm::Attribute::AttrKind::OptForFuzzing));
-    attributeKinds.Set("OptimizeForSize", Napi::Number::New(env, llvm::Attribute::AttrKind::OptimizeForSize));
-    attributeKinds.Set("OptimizeNone", Napi::Number::New(env, llvm::Attribute::AttrKind::OptimizeNone));
-    attributeKinds.Set("ReadNone", Napi::Number::New(env, llvm::Attribute::AttrKind::ReadNone));
-    attributeKinds.Set("ReadOnly", Napi::Number::New(env, llvm::Attribute::AttrKind::ReadOnly));
-    attributeKinds.Set("Returned", Napi::Number::New(env, llvm::Attribute::AttrKind::Returned));
-    attributeKinds.Set("ReturnsTwice", Napi::Number::New(env, llvm::Attribute::AttrKind::ReturnsTwice));
-    attributeKinds.Set("SExt", Napi::Number::New(env, llvm::Attribute::AttrKind::SExt));
-    attributeKinds.Set("SafeStack", Napi::Number::New(env, llvm::Attribute::AttrKind::SafeStack));
-    attributeKinds.Set("SanitizeAddress", Napi::Number::New(env, llvm::Attribute::AttrKind::SanitizeAddress));
-    attributeKinds.Set("SanitizeHWAddress", Napi::Number::New(env, llvm::Attribute::AttrKind::SanitizeHWAddress));
-    attributeKinds.Set("SanitizeMemTag", Napi::Number::New(env, llvm::Attribute::AttrKind::SanitizeMemTag));
-    attributeKinds.Set("SanitizeMemory", Napi::Number::New(env, llvm::Attribute::AttrKind::SanitizeMemory));
-    attributeKinds.Set("SanitizeThread", Napi::Number::New(env, llvm::Attribute::AttrKind::SanitizeThread));
-    attributeKinds.Set("ShadowCallStack", Napi::Number::New(env, llvm::Attribute::AttrKind::ShadowCallStack));
-    attributeKinds.Set("Speculatable", Napi::Number::New(env, llvm::Attribute::AttrKind::Speculatable));
-    attributeKinds.Set("SpeculativeLoadHardening",
-                       Napi::Number::New(env, llvm::Attribute::AttrKind::SpeculativeLoadHardening));
-    attributeKinds.Set("StackProtect", Napi::Number::New(env, llvm::Attribute::AttrKind::StackProtect));
-    attributeKinds.Set("StackProtectReq", Napi::Number::New(env, llvm::Attribute::AttrKind::StackProtectReq));
-    attributeKinds.Set("StackProtectStrong", Napi::Number::New(env, llvm::Attribute::AttrKind::StackProtectStrong));
-    attributeKinds.Set("StrictFP", Napi::Number::New(env, llvm::Attribute::AttrKind::StrictFP));
-    attributeKinds.Set("SwiftAsync", Napi::Number::New(env, llvm::Attribute::AttrKind::SwiftAsync));
-    attributeKinds.Set("SwiftError", Napi::Number::New(env, llvm::Attribute::AttrKind::SwiftError));
-    attributeKinds.Set("SwiftSelf", Napi::Number::New(env, llvm::Attribute::AttrKind::SwiftSelf));
-    attributeKinds.Set("UWTable", Napi::Number::New(env, llvm::Attribute::AttrKind::UWTable));
-    attributeKinds.Set("WillReturn", Napi::Number::New(env, llvm::Attribute::AttrKind::WillReturn));
-    attributeKinds.Set("WriteOnly", Napi::Number::New(env, llvm::Attribute::AttrKind::WriteOnly));
-    attributeKinds.Set("LastEnumAttr", Napi::Number::New(env, llvm::Attribute::AttrKind::LastEnumAttr));
-    attributeKinds.Set("ByRef", Napi::Number::New(env, llvm::Attribute::AttrKind::ByRef));
-    attributeKinds.Set("ByVal", Napi::Number::New(env, llvm::Attribute::AttrKind::ByVal));
-    attributeKinds.Set("ElementType", Napi::Number::New(env, llvm::Attribute::AttrKind::ElementType));
-    attributeKinds.Set("InAlloca", Napi::Number::New(env, llvm::Attribute::AttrKind::InAlloca));
-    attributeKinds.Set("Preallocated", Napi::Number::New(env, llvm::Attribute::AttrKind::Preallocated));
-    attributeKinds.Set("LastTypeAttr", Napi::Number::New(env, llvm::Attribute::AttrKind::LastTypeAttr));
-    attributeKinds.Set("Alignment", Napi::Number::New(env, llvm::Attribute::AttrKind::Alignment));
-    attributeKinds.Set("AllocSize", Napi::Number::New(env, llvm::Attribute::AttrKind::AllocSize));
-    attributeKinds.Set("Dereferenceable", Napi::Number::New(env, llvm::Attribute::AttrKind::Dereferenceable));
-    attributeKinds.Set("DereferenceableOrNull",
-                       Napi::Number::New(env, llvm::Attribute::AttrKind::DereferenceableOrNull));
-    attributeKinds.Set("StackAlignment", Napi::Number::New(env, llvm::Attribute::AttrKind::StackAlignment));
-    attributeKinds.Set("VScaleRange", Napi::Number::New(env, llvm::Attribute::AttrKind::VScaleRange));
+
+#define ATTRIBUTE_ENUM(EnumName, lower) attributeKinds.Set(#EnumName, Napi::Number::New(env, llvm::Attribute::AttrKind::##EnumName));
+#include "llvm/IR/Attributes.inc"
 
     Napi::Function func = DefineClass(env, "Attribute", {
             StaticValue("AttrKind", attributeKinds),

--- a/src/IR/DataLayout.cpp
+++ b/src/IR/DataLayout.cpp
@@ -53,7 +53,7 @@ Napi::Value DataLayout::getTypeAllocSize(const Napi::CallbackInfo &info) {
     if (info.Length() == 1 && Type::IsClassOf(info[0])) {
         llvm::Type *type = Type::Extract(info[0]);
         auto allocSize = dataLayout->getTypeAllocSize(type);
-        return Napi::Number::New(env, double(allocSize.getFixedSize()));
+        return Napi::Number::New(env, static_cast<double>(allocSize.getFixedValue()));
     }
     throw Napi::TypeError::New(env, ErrMsg::Class::DataLayout::getTypeAllocSize);
 }

--- a/src/IR/DerivedTypes.cpp
+++ b/src/IR/DerivedTypes.cpp
@@ -565,7 +565,7 @@ void PointerType::Init(Napi::Env env, Napi::Object &exports) {
             InstanceMethod("isIntegerTy", &PointerType::isIntegerTy),
             InstanceMethod("isVoidTy", &PointerType::isVoidTy),
             InstanceMethod("getTypeID", &PointerType::getTypeID),
-            InstanceMethod("getPointerElementType", &PointerType::getPointerElementType)
+            InstanceMethod("getNonOpaquePointerElementType", &PointerType::getNonOpaquePointerElementType)
     });
     constructor = Napi::Persistent(func);
     constructor.SuppressDestruct();
@@ -647,6 +647,6 @@ Napi::Value PointerType::getTypeID(const Napi::CallbackInfo &info) {
     return Napi::Number::New(info.Env(), pointerType->getTypeID());
 }
 
-Napi::Value PointerType::getPointerElementType(const Napi::CallbackInfo &info) {
-    return Type::New(info.Env(), pointerType->getPointerElementType());
+Napi::Value PointerType::getNonOpaquePointerElementType(const Napi::CallbackInfo &info) {
+    return Type::New(info.Env(), pointerType->getNonOpaquePointerElementType());
 }

--- a/src/IR/Function.cpp
+++ b/src/IR/Function.cpp
@@ -111,7 +111,7 @@ void Function::addBasicBlock(const Napi::CallbackInfo &info) {
         throw Napi::TypeError::New(env, ErrMsg::Class::Function::addBasicBlock);
     }
     llvm::BasicBlock *basicBlock = BasicBlock::Extract(info[0]);
-    function->getBasicBlockList().push_back(basicBlock);
+    function->insert(function->end(), basicBlock);
 }
 
 Napi::Value Function::getEntryBlock(const Napi::CallbackInfo &info) {
@@ -129,7 +129,7 @@ void Function::insertAfter(const Napi::CallbackInfo &info) {
     }
     llvm::BasicBlock *where = BasicBlock::Extract(info[0]);
     llvm::BasicBlock *bb = BasicBlock::Extract(info[1]);
-    function->getBasicBlockList().insertAfter(where->getIterator(), bb);
+    function->insert(where->getIterator(), bb);
 }
 
 void Function::deleteBody(const Napi::CallbackInfo &info) {

--- a/src/IR/IRBuilder.cpp
+++ b/src/IR/IRBuilder.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "IR/index.h"
 #include "ADT/APInt.h"
 #include "Util/index.h"

--- a/src/IR/IRBuilder.cpp
+++ b/src/IR/IRBuilder.cpp
@@ -486,7 +486,7 @@ Napi::Value IRBuilder::CreateInvoke(const Napi::CallbackInfo &info) {
         llvm::BasicBlock *normalDest = BasicBlock::Extract(info[1]);
         llvm::BasicBlock *unwindDest = BasicBlock::Extract(info[2]);
         std::string name = argsLen == 4 ? std::string(info[3].As<Napi::String>()) : "";
-        invokeInst = builder->CreateInvoke(callee, normalDest, unwindDest, llvm::None, name);
+        invokeInst = builder->CreateInvoke(callee, normalDest, unwindDest, std::nullopt, name);
     } else if (argsLen == 4 && Function::IsClassOf(info[0]) && BasicBlock::IsClassOf(info[1]) && BasicBlock::IsClassOf(info[2]) && info[3].IsArray() ||
                argsLen == 5 && Function::IsClassOf(info[0]) && BasicBlock::IsClassOf(info[1]) && BasicBlock::IsClassOf(info[2]) && info[3].IsArray() && info[4].IsString()) {
         if (assembleArray<WrappedValue>(info[3].As<Napi::Array>(), calleeArgs)) {
@@ -502,7 +502,7 @@ Napi::Value IRBuilder::CreateInvoke(const Napi::CallbackInfo &info) {
         llvm::BasicBlock *normalDest = BasicBlock::Extract(info[1]);
         llvm::BasicBlock *unwindDest = BasicBlock::Extract(info[2]);
         std::string name = argsLen == 4 ? std::string(info[3].As<Napi::String>()) : "";
-        invokeInst = builder->CreateInvoke(callee, normalDest, unwindDest, llvm::None, name);
+        invokeInst = builder->CreateInvoke(callee, normalDest, unwindDest, std::nullopt, name);
     } else if (argsLen == 4 && FunctionCallee::IsClassOf(info[0]) && BasicBlock::IsClassOf(info[1]) && BasicBlock::IsClassOf(info[2]) && info[3].IsArray() ||
                argsLen == 5 && FunctionCallee::IsClassOf(info[0]) && BasicBlock::IsClassOf(info[1]) && BasicBlock::IsClassOf(info[2]) && info[3].IsArray() && info[4].IsString()) {
         if (assembleArray<WrappedValue>(info[3].As<Napi::Array>(), calleeArgs)) {
@@ -521,7 +521,7 @@ Napi::Value IRBuilder::CreateInvoke(const Napi::CallbackInfo &info) {
         llvm::BasicBlock *normalDest = BasicBlock::Extract(info[2]);
         llvm::BasicBlock *unwindDest = BasicBlock::Extract(info[3]);
         std::string name = argsLen == 5 ? std::string(info[4].As<Napi::String>()) : "";
-        invokeInst = builder->CreateInvoke(funcType, callee, normalDest, unwindDest, llvm::None, name);
+        invokeInst = builder->CreateInvoke(funcType, callee, normalDest, unwindDest, std::nullopt, name);
     } else if (argsLen == 5 && FunctionType::IsClassOf(info[0]) && Function::IsClassOf(info[1]) && BasicBlock::IsClassOf(info[2]) &&
                BasicBlock::IsClassOf(info[3]) && info[4].IsArray() ||
                argsLen == 6 && FunctionType::IsClassOf(info[0]) && Function::IsClassOf(info[1]) && BasicBlock::IsClassOf(info[2]) &&
@@ -699,7 +699,7 @@ Napi::Value IRBuilder::CreateCall(const Napi::CallbackInfo &info) {
         argsLen == 2 && Function::IsClassOf(info[0]) && info[1].IsString()) {
         llvm::Function *callee = Function::Extract(info[0]);
         std::string name = argsLen == 2 ? std::string(info[1].As<Napi::String>()) : "";
-        callInst = builder->CreateCall(callee, llvm::None, name);
+        callInst = builder->CreateCall(callee, std::nullopt, name);
     } else if (argsLen == 2 && Function::IsClassOf(info[0]) && info[1].IsArray() ||
                argsLen == 3 && Function::IsClassOf(info[0]) && info[1].IsArray() && info[2].IsString()) {
         if (assembleArray<WrappedValue>(info[1].As<Napi::Array>(), calleeArgs)) {
@@ -711,7 +711,7 @@ Napi::Value IRBuilder::CreateCall(const Napi::CallbackInfo &info) {
                argsLen == 2 && FunctionCallee::IsClassOf(info[0]) && info[1].IsString()) {
         llvm::FunctionCallee callee = FunctionCallee::Extract(info[0]);
         std::string name = argsLen == 2 ? std::string(info[1].As<Napi::String>()) : "";
-        callInst = builder->CreateCall(callee, llvm::None, name);
+        callInst = builder->CreateCall(callee, std::nullopt, name);
     } else if (argsLen == 2 && FunctionCallee::IsClassOf(info[0]) && info[1].IsArray() ||
                argsLen == 3 && FunctionCallee::IsClassOf(info[0]) && info[1].IsArray() && info[2].IsString()) {
         if (assembleArray<WrappedValue>(info[1].As<Napi::Array>(), calleeArgs)) {
@@ -724,7 +724,7 @@ Napi::Value IRBuilder::CreateCall(const Napi::CallbackInfo &info) {
         llvm::FunctionType *funcType = FunctionType::Extract(info[0]);
         llvm::Value *callee = Value::Extract(info[1]);
         std::string name = argsLen == 3 ? std::string(info[2].As<Napi::String>()) : "";
-        callInst = builder->CreateCall(funcType, callee, llvm::None, name);
+        callInst = builder->CreateCall(funcType, callee, std::nullopt, name);
     } else if (argsLen == 3 && FunctionType::IsClassOf(info[0]) && Value::IsClassOf(info[1]) && info[2].IsArray() ||
                argsLen == 4 && FunctionType::IsClassOf(info[0]) && Value::IsClassOf(info[1]) && info[2].IsArray() && info[3].IsString()) {
         if (assembleArray<WrappedValue>(info[2].As<Napi::Array>(), calleeArgs)) {

--- a/src/IR/Intrinsic.cpp
+++ b/src/IR/Intrinsic.cpp
@@ -107,7 +107,6 @@ void Intrinsic::Init(Napi::Env env, Napi::Object &exports) {
     intrinsicNS.Set("expect_with_probability", Napi::Number::New(env, llvm::Intrinsic::expect_with_probability));
     intrinsicNS.Set("fabs", Napi::Number::New(env, llvm::Intrinsic::fabs));
     intrinsicNS.Set("floor", Napi::Number::New(env, llvm::Intrinsic::floor));
-    intrinsicNS.Set("flt_rounds", Napi::Number::New(env, llvm::Intrinsic::flt_rounds));
     intrinsicNS.Set("fma", Napi::Number::New(env, llvm::Intrinsic::fma));
     intrinsicNS.Set("fmuladd", Napi::Number::New(env, llvm::Intrinsic::fmuladd));
     intrinsicNS.Set("fptosi_sat", Napi::Number::New(env, llvm::Intrinsic::fptosi_sat));

--- a/src/MC/TargetRegistry.cpp
+++ b/src/MC/TargetRegistry.cpp
@@ -45,7 +45,8 @@ Napi::Value Target::createTargetMachine(const Napi::CallbackInfo &info) {
         features = info[2].As<Napi::String>();
     }
     llvm::TargetOptions options{};
-    llvm::TargetMachine *targetMachinePtr = target->createTargetMachine(targetTriple, cpu, features, options, llvm::Optional<llvm::Reloc::Model>{});
+    llvm::TargetMachine *targetMachinePtr = target->createTargetMachine(
+        targetTriple, cpu, features, options, std::optional<llvm::Reloc::Model>{});
     return TargetMachine::New(env, targetMachinePtr);
 }
 

--- a/src/llvm-bindings.cpp
+++ b/src/llvm-bindings.cpp
@@ -9,7 +9,27 @@
 #include "Support/index.h"
 #include "Target/index.h"
 
+template<typename ... Args>
+std::string string_format( const std::string& format, Args ... args )
+{
+    int size_s = std::snprintf( nullptr, 0, format.c_str(), args ... ) + 1; // Extra space for '\0'
+    if( size_s <= 0 ){ throw std::runtime_error( "Error during formatting." ); }
+    auto size = static_cast<size_t>( size_s );
+    std::unique_ptr<char[]> buf( new char[ size ] );
+    std::snprintf( buf.get(), size, format.c_str(), args ... );
+    return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
+}
+
+static std::unique_ptr<Napi::Env> node_env;
+
+void llvm_bindings_assert(const char* e, const char* file, int line)
+{
+    throw Napi::Error::New(
+        *node_env, string_format("%s:%d: failed assertion `%s'\n", file, line, e));
+}
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    node_env = std::make_unique<Napi::Env>(env);
     InitADT(env, exports);
     InitBinaryFormat(env, exports);
     InitBitCode(env, exports);

--- a/test/exception.ts
+++ b/test/exception.ts
@@ -27,7 +27,7 @@ export default function testException() {
     const tmp2 = builder.CreateBitCast(tmp1, llvm.PointerType.getUnqual(builder.getInt8PtrTy()));
     builder.CreateStore(
         builder.CreateInBoundsGEP(
-            errMsgStr.getType().getPointerElementType(),
+            errMsgStr.getValueType(),
             errMsgStr,
             [builder.getInt64(0), builder.getInt64(0)]
         ),


### PR DESCRIPTION
I added support for LLVM 16. In an effort to make future porting a little easier, I made use of the `llvm/IR/Attributes.inc` where attributes are defined. The attribute declaration macros are overridden to have the preprocessor register the attributes for us.

The TS declaration are also passed through the preprocessor so that they are also updated from version to version.

I also added an override to <assert.h> that throws a NodeJS error by default so that its easier to debug LLVM assertion failures in the JS context